### PR TITLE
Cache HTTP errors to reduce load spikes; rule name update

### DIFF
--- a/akamai/data/base_rules.json
+++ b/akamai/data/base_rules.json
@@ -209,11 +209,19 @@
                         "options": {
                             "behavior": "ALWAYS"
                         }
+                    },
+                    {
+                        "name": "cacheError",
+                        "options": {
+                            "enabled": true,
+                            "ttl": "10m",
+                            "preserveStale": true
+                        }
                     }
                 ],
                 "criteria": [],
                 "criteriaMustSatisfy": "all",
-                "name": "Cloud Services Prerelease",
+                "name": "Cloud Services Frontend",
                 "children": []
             },
             {

--- a/akamai/data/base_rules.json
+++ b/akamai/data/base_rules.json
@@ -240,7 +240,7 @@
                             "cacheKeyHostname": "ORIGIN_HOSTNAME",
                             "forwardHostHeader": "ORIGIN_HOSTNAME",
                             "originSni": true,
-                            "verificationMode": "PLATFORM_SETTINGS",
+                            "verificationMode": "CUSTOM",
                             "hostname": "api-gateway.1b13.insights.openshiftapps.com",
                             "compress": true,
                             "trueClientIpHeader": "True-Client-IP",
@@ -250,7 +250,45 @@
                             "trueClientIpClientSetting": false,
                             "originType": "CUSTOMER",
                             "ports": "",
-                            "originCertificate": ""
+                            "originCertificate": "",
+                            "customValidCnValues": [
+                                "{{Origin Hostname}}",
+                                "{{Forward Host Header}}",
+                                "*.1b13.insights.openshiftapps.com"
+                            ],
+                            "originCertsToHonor": "COMBO",
+                            "standardCertificateAuthorities": [
+                                "akamai-permissive"
+                            ],
+                            "customCertificateAuthorities": [
+                                {
+                                    "subjectCN": "Let's Encrypt Authority X3",
+                                    "subjectAlternativeNames": [],
+                                    "subjectRDNs": {
+                                        "C": "US",
+                                        "CN": "Let's Encrypt Authority X3",
+                                        "O": "Let's Encrypt"
+                                    },
+                                    "issuerRDNs": {
+                                        "CN": "DST Root CA X3",
+                                        "O": "Digital Signature Trust Co."
+                                    },
+                                    "notBefore": 1458232846000,
+                                    "notAfter": 1615999246000,
+                                    "sigAlgName": "SHA256WITHRSA",
+                                    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnNMM8FrlLke3cl03g7NoYzDq1zUmGSXhvb418XCSL7e4S0EFq6meNQhY7LEqxGiHC6PjdeTm86dicbp5gWAf15Gan/PQeGdxyGkOlZHP/uaZ6WA8SMx+yk13EiSdRxta67nsHjcAHJyse6cF6s5K671B5TaYucv9bTyWaN8jKkKQDIZ0Z8h/pZq4UmEUEz9l6YKHy9v6Dlb2honzhT+Xhq+w3Brvaw2VFn3EK6BlspkENnWAa6xK8xuQSXgvopZPKiAlKQTGdMDQMc2PMTiVFrqoM7hD8bEfwzB/onkxEz0tNvjj/PIzark5McWvxI0NHWQWM6r6hCm21AvA2H3DkwIDAQAB",
+                                    "publicKeyAlgorithm": "RSA",
+                                    "publicKeyFormat": "X.509",
+                                    "serialNumber": 1.3298795840390664e+37,
+                                    "version": 3,
+                                    "sha1Fingerprint": "e6a3b45b062d509b3382282d196efe97d5956ccb",
+                                    "pemEncodedCert": "-----BEGIN CERTIFICATE-----\nMIIEkjCCA3qgAwIBAgIQCgFBQgAAAVOFc2oLheynCDANBgkqhkiG9w0BAQsFADA/\nMSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT\nDkRTVCBSb290IENBIFgzMB4XDTE2MDMxNzE2NDA0NloXDTIxMDMxNzE2NDA0Nlow\nSjELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUxldCdzIEVuY3J5cHQxIzAhBgNVBAMT\nGkxldCdzIEVuY3J5cHQgQXV0aG9yaXR5IFgzMIIBIjANBgkqhkiG9w0BAQEFAAOC\nAQ8AMIIBCgKCAQEAnNMM8FrlLke3cl03g7NoYzDq1zUmGSXhvb418XCSL7e4S0EF\nq6meNQhY7LEqxGiHC6PjdeTm86dicbp5gWAf15Gan/PQeGdxyGkOlZHP/uaZ6WA8\nSMx+yk13EiSdRxta67nsHjcAHJyse6cF6s5K671B5TaYucv9bTyWaN8jKkKQDIZ0\nZ8h/pZq4UmEUEz9l6YKHy9v6Dlb2honzhT+Xhq+w3Brvaw2VFn3EK6BlspkENnWA\na6xK8xuQSXgvopZPKiAlKQTGdMDQMc2PMTiVFrqoM7hD8bEfwzB/onkxEz0tNvjj\n/PIzark5McWvxI0NHWQWM6r6hCm21AvA2H3DkwIDAQABo4IBfTCCAXkwEgYDVR0T\nAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwfwYIKwYBBQUHAQEEczBxMDIG\nCCsGAQUFBzABhiZodHRwOi8vaXNyZy50cnVzdGlkLm9jc3AuaWRlbnRydXN0LmNv\nbTA7BggrBgEFBQcwAoYvaHR0cDovL2FwcHMuaWRlbnRydXN0LmNvbS9yb290cy9k\nc3Ryb290Y2F4My5wN2MwHwYDVR0jBBgwFoAUxKexpHsscfrb4UuQdf/EFWCFiRAw\nVAYDVR0gBE0wSzAIBgZngQwBAgEwPwYLKwYBBAGC3xMBAQEwMDAuBggrBgEFBQcC\nARYiaHR0cDovL2Nwcy5yb290LXgxLmxldHNlbmNyeXB0Lm9yZzA8BgNVHR8ENTAz\nMDGgL6AthitodHRwOi8vY3JsLmlkZW50cnVzdC5jb20vRFNUUk9PVENBWDNDUkwu\nY3JsMB0GA1UdDgQWBBSoSmpjBH3duubRObemRWXv86jsoTANBgkqhkiG9w0BAQsF\nAAOCAQEA3TPXEfNjWDjdGBX7CVW+dla5cEilaUcne8IkCJLxWh9KEik3JHRRHGJo\nuM2VcGfl96S8TihRzZvoroed6ti6WqEBmtzw3Wodatg+VyOeph4EYpr/1wXKtx8/\nwApIvJSwtmVi4MFU5aMqrSDE6ea73Mj2tcMyo5jMd6jmeWUHK8so/joWUoHOUgwu\nX4Po1QYz+3dszkDqMp4fklxBwXRsW10KXzPMTZ+sOPAveyxindmjkW8lGy+QsRlG\nPfZ+G6Z6h7mjem0Y+iWlkYcV4PIWL1iwBi8saCbGS5jN2p8M+X+Q7UNKEkROb3N6\nKOqkqm57TH2H3eDJAkSnh6/DNFu0Qg==\n-----END CERTIFICATE-----\n",
+                                    "canBeLeaf": true,
+                                    "canBeCA": true,
+                                    "selfSigned": false
+                                }
+                            ],
+                            "customCertificates": []
                         }
                     },
                     {


### PR DESCRIPTION
I talked to Kyle Lape and found that when Akamai has lag spikes, our site could hang for upwards of 20 seconds just to finally present the user with a 404. Akamai reps recommended caching HTTP errors, so I'm doing that (for frontend only, not API).

I also updated one of the rule labels, just because we're not pre-release anymore.