### PR TITLE
Add migration-analytics configuration

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -288,4 +288,5 @@ migration-analytics:
     paths:
       - /migration-analytics
   git_repo: https://github.com/project-xavier/xavier-ui
+  mailing_list: migration-analytics-devel@redhat.com
   top_level: true

--- a/main.yml
+++ b/main.yml
@@ -286,7 +286,7 @@ migration-analytics:
   disabled_on_stable: true
   frontend:
     paths:
-      - /migration-analytics
+      - /apps/migration-analytics
   git_repo: https://github.com/project-xavier/xavier-ui
   mailing_list: migration-analytics-devel@redhat.com
   top_level: true

--- a/main.yml
+++ b/main.yml
@@ -275,3 +275,18 @@ vulnerability:
     title: Vulnerability
     paths:
       - /rhel/vulnerability
+
+migration-analytics:
+  title: Migration Analytics
+  api:
+    versions:
+      - v1
+  deployment_repo: https://github.com/RedHatInsights/xavier-ui-deploy
+  disabled_on_prod: true
+  disabled_on_stable: true
+  frontend:
+    paths:
+      - /migration-analytics
+  git_repo: https://github.com/project-xavier/xavier-ui
+  mailing_list: 
+  top_level: true

--- a/main.yml
+++ b/main.yml
@@ -288,5 +288,4 @@ migration-analytics:
     paths:
       - /migration-analytics
   git_repo: https://github.com/project-xavier/xavier-ui
-  mailing_list: 
   top_level: true


### PR DESCRIPTION
Migration Analytics will have his own bundle, not accessible directly from landing page. In the future, we could create a button on the landing page that would bring users to this comparison page.