### PR TITLE
Add Subscription Reporting to main.yml

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -310,7 +310,22 @@ staging:
     sub_apps:
       - id: migration-analytics
       - id: ruledev
+      - id: subscription-reporting
   top_level: true
+
+subscription-reporting:
+  title: Subscription Reporting
+  api:
+    versions:
+      - v1
+  channel: '#subscriptions'
+  deployment_repo: https://github.com/RedHatInsights/curiosity-frontend-build
+  disabled_on_prod: true
+  disabled_on_stable: true
+  frontend:
+    paths:
+      - /staging/subscription-reporting
+  git_repo: https://github.com/RedHatInsights/curiosity-frontend
 
 tower-analytics:
   title: Ansible Tower Analytics


### PR DESCRIPTION
Subscription Reporting bundle, currently not accessible directly from landing page. 

Similar to Migration Analytics in settings, where within the near future, the plan is to expose a Subscription Reporting aspect at a landing page level.

We had an alternative approach for layout where the GUI build currently being referenced within this PR
-`https://github.com/RedHatInsights/curiosity-frontend-build` 

... was laid out as a child app of a `Subscription Reporting` parent. But it appears easy enough  to update through this config when that decision comes through

@kruai