### PR TITLE
Update docs to full name documentation allow accessing /docs to api

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -9,7 +9,7 @@ approval:
       - /hybrid/catalog/approval
     reload: catalog/approval
 
-api:
+api-docs:
   title: API documentation
   deployment_repo: https://github.com/RedHatInsights/api-frontend-build
   frontend:
@@ -96,12 +96,12 @@ dashboard:
       - /rhel
       - /rhel/dashboard
 
-docs:
+cs-docs:
   title: Documentation
   channel: '#flip-mode-squad'
   frontend:
     sub_apps:
-      - id: api
+      - id: api-docs
         default: true
   top_level: true
 

--- a/main.yml
+++ b/main.yml
@@ -10,11 +10,12 @@ approval:
     reload: catalog/approval
 
 api:
-  title: Api docs
+  title: API documentation
   deployment_repo: https://github.com/RedHatInsights/api-frontend-build
   frontend:
     paths:
       - /docs/api
+      - /docs
 
 catalog:
   title: Catalog
@@ -96,7 +97,7 @@ dashboard:
       - /rhel/dashboard
 
 docs:
-  title: Cloud Services documentation
+  title: Documentation
   channel: '#flip-mode-squad'
   frontend:
     sub_apps:


### PR DESCRIPTION
* Rename api docs to api documentation
* Rename cloud Services documentation to documentation
* When user hits `/docs` redirect him to `/docs/api`