### PR TITLE
Add cost model details page to main.yml under cost management

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -84,6 +84,8 @@ cost-management:
         title: OpenShift details
       - id: aws
         title: Cloud details
+      - id: cost-models
+        title: Cost model details
   git_repo: https://github.com/project-koku/
   mailing_list: cost-mgmt@redhat.com
 


### PR DESCRIPTION
Add cost-models path to the navigation sidebar for cost model details page in cost management.

//cc @ryelo 
merge after https://github.com/project-koku/koku-ui/pull/926
