### PR TITLE
Activate Subscription Reporting

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -320,19 +320,18 @@ staging:
       - id: subscription-reporting
   top_level: true
 
-subscription-reporting:
+subscriptions:
   title: Subscription Reporting
   api:
     versions:
       - v1
   channel: '#subscriptions'
   deployment_repo: https://github.com/RedHatInsights/curiosity-frontend-build
-  disabled_on_prod: true
-  disabled_on_stable: true
   frontend:
     paths:
-      - /staging/subscription-reporting
+      - /subscriptions
   git_repo: https://github.com/RedHatInsights/curiosity-frontend
+  top_level: true
 
 tower-analytics:
   title: Ansible Tower Analytics


### PR DESCRIPTION
## Description
Subscription Reporting bundle, remove `disabled`.

## Notes
- remove `disabled_` config settings. 
- create as top level without a card on the landing page, should be accessible from direct link only. may need some input on how to structure this. it is a config so feels pretty open... 

   Since it appears the config aims to have landing areas standalone'ish, an alternative possibility we came up with is here. We currently only have one path/route:

   ```
   subscriptions:
     title: Subscription Reporting
     channel: '#subscriptions'
     frontend:
       sub_apps:
         - id: subscription-rhel
           default: true
     top_level: true
   
   subscriptions-rhel:
     title: Red Hat Enterprise Linux
     api:
       versions:
         - v1
     deployment_repo: https://github.com/RedHatInsights/curiosity-frontend-build
     frontend:
       paths:
         - /subscriptions/rhel
     git_repo: https://github.com/RedHatInsights/curiosity-frontend
   ```


@kruai @ryelo @karelhala 
