### PR TITLE
WIP Update Subscription Reporting

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -313,10 +313,9 @@ staging:
     sub_apps:
       - id: migration-analytics
       - id: ruledev
-      - id: subscription-reporting
   top_level: true
 
-subscription-reporting:
+subscriptions:
   title: Subscription Reporting
   api:
     versions:
@@ -325,8 +324,9 @@ subscription-reporting:
   deployment_repo: https://github.com/RedHatInsights/curiosity-frontend-build
   frontend:
     paths:
-      - /staging/subscription-reporting
+      - /subscriptions
   git_repo: https://github.com/RedHatInsights/curiosity-frontend
+  top_level: true
 
 tower-analytics:
   title: Ansible Tower Analytics


### PR DESCRIPTION
## Description
Subscription Reporting bundle. Once we get this format worked out we'll open a PR against `ci-stable` per the README

## Notes
- create as top level **without** a card on the landing page, should be accessible from direct link only.

    ![Screen Shot 2019-08-05 at 11 37 30 AM](https://user-images.githubusercontent.com/3761375/62476772-a3e10300-b775-11e9-93c4-65227c1d2276.png) 

   Since it looks like the config aims to have landing areas we have an alternative config layout below. A little unsure of one thing since we currently only have the one route `[app]/rhel`... 
   - Updating App ID appears obvious, we'd just update towards `subscriptions-rhel`
   - However, since we're splitting the app out using the below config were a little unsure what path our app would be hosted at. Need confirmation, would it still be `/apps/subscriptions`?
   
   #### Alternative
   ```
   subscriptions:
     title: Subscription Reporting
     channel: '#subscriptions'
     frontend:
       sub_apps:
         - id: subscription-rhel
           default: true
     top_level: true
   
   subscriptions-rhel:
     title: Red Hat Enterprise Linux
     api:
       versions:
         - v1
     deployment_repo: https://github.com/RedHatInsights/curiosity-frontend-build
     frontend:
       paths:
         - /subscriptions/rhel
     git_repo: https://github.com/RedHatInsights/curiosity-frontend
   ```

@kruai @ryelo @karelhala 
