### PR TITLE
update to left-hand nav for system comparison

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -118,9 +118,15 @@ drift:
       - v1
   deployment_repo: https://github.com/RedHatInsights/drift-frontend-build
   frontend:
-    title: System Comparison
+    title: Drift Analysis
     paths:
       - /rhel/drift
+    sub_apps:
+      - id: ''
+        title: System Comparison
+        default: true
+      - id: baselines
+        title: Baselines
 
 hooks:
   title: Web Hooks Service


### PR DESCRIPTION
This commit renamed "System Comparison" to "Drift Analysis". It also
creates two submenu items, one for "System Comparison", and one for
"Baselines".