### PR TITLE
Add tags and isBeta to some APIs

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -62,6 +62,7 @@ cost-management:
   api:
     versions:
       - v1
+    isBeta: true
   channel: '#koku'
   deployment_repo: https://github.com/RedHatInsights/cost-management-build
   description: >
@@ -135,6 +136,7 @@ hooks:
   api:
     versions:
       - v1
+    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/notifications-frontend-build.git
   frontend:
     title: Hooks
@@ -196,9 +198,6 @@ landing:
 
 migrations:
   title: Migrations
-  api: 
-    versions:
-      - v1
   frontend: 
     title: Migrations
     sub_apps:
@@ -211,6 +210,9 @@ migration-analytics:
   api:
     versions:
       - v1
+    isBeta: true
+    alias:
+      - xavier
     tags:
       - value: "experimental"
         title: "Experimental API"
@@ -288,6 +290,7 @@ ruledev:
   api:
     versions:
       - v1
+    isBeta: true
     tags:
       - value: "experimental"
         title: "Experimental API"
@@ -356,6 +359,7 @@ subscriptions:
     tags:
       - value: "experimental"
         title: "Experimental API"
+    isBeta: true
   channel: '#subscriptions'
   deployment_repo: https://github.com/RedHatInsights/curiosity-frontend-build
   frontend:
@@ -368,6 +372,7 @@ topological-inventory:
   api:
     versions:
       - v1.0
+    isBeta: true
   channel: '#insights_topology_svc'
   deployment_repo: https://github.com/RedHatInsights/topological-inventory-frontend-build
   frontend:
@@ -379,6 +384,7 @@ tower-analytics:
   api:
     versions:
       - v1
+    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/tower-analytics-frontend-build.git
 
 vulnerability:

--- a/main.yml
+++ b/main.yml
@@ -11,6 +11,7 @@ approval:
   api:
     versions:
       - v1
+    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/approvals-frontend-deploy.git
   frontend:
     paths:
@@ -22,6 +23,7 @@ catalog:
   api:
     versions:
       - v1
+    isBeta: true
   channel: '#insights-svc-portal'
   deployment_repo: https://github.com/RedHatInsights/catalog-static-deploy
   frontend:
@@ -209,6 +211,9 @@ migration-analytics:
   api:
     versions:
       - v1
+    tags:
+      - value: "experimental"
+        title: "Experimental API"
   deployment_repo: https://github.com/RedHatInsights/xavier-ui-deploy
   frontend:
     paths:
@@ -238,6 +243,7 @@ rbac:
   api:
     versions:
       - v1
+    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/rbac-frontend-deploy.git
   frontend:
     title: User Access Management
@@ -282,6 +288,9 @@ ruledev:
   api:
     versions:
       - v1
+    tags:
+      - value: "experimental"
+        title: "Experimental API"
   channel: '#flip-mode-squad'
   deployment_repo: https://github.com/RedHatInsights/ruledev-frontend-build
   frontend:
@@ -313,6 +322,7 @@ sources:
   api:
     versions:
       - v1
+    isBeta: true
   channel: '#insights_topology_svc'
   deployment_repo: https://github.com/RedHatInsights/sources-ui-deploy
   frontend:
@@ -343,6 +353,9 @@ subscriptions:
   api:
     versions:
       - v1
+    tags:
+      - value: "experimental"
+        title: "Experimental API"
   channel: '#subscriptions'
   deployment_repo: https://github.com/RedHatInsights/curiosity-frontend-build
   frontend:


### PR DESCRIPTION
@kruai I've rather added `isBeta` to all env that are supposed to be available on beta, if you want I can remove it from some places (like migrations, ansible tower, subscriptions, ruledev and hooks).