### PR TITLE
Reload approval app

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -28,6 +28,7 @@ approval:
     paths:
       - /hybrid/catalog/approval
       - /ansible/catalog/approval
+    reload: catalog/approval
 
 automation-analytics:
   title: Automation Analytics


### PR DESCRIPTION
**Description**

Approval is not a part of Catalog, so the `reload` option is added.

@karelhala 