### PR TITLE
add group to openshift sub apps

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -278,9 +278,11 @@ openshift:
     sub_apps:
       - id: ''
         title: Clusters
+        group: openshift
         default: true
       - id: subscriptions
         title: Subscriptions
+        group: openshift
   top_level: true
 
 rbac:


### PR DESCRIPTION
@elad661 @kruai @ryelo 
our team do not want page reloading when clicking on nav items,
https://cloud.redhat.com/beta/openshift

I found an example,
https://cloud.redhat.com/insights/overview

Here's its config,
https://github.com/RedHatInsights/cloud-services-config/blob/ci-beta/main.yml#L210-L219

It seems we are missing `group`. Cloud you review?
- thanks!