### PR TITLE
Remove some apps from Stable

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -1,14 +1,3 @@
-ansible:
-  title: Red Hat Ansible Automation Platform
-  frontend:
-    sub_apps:
-      - id: automation-analytics
-        default: true
-      - id: automation-hub
-      - id: catalog
-      - id: settings-ansible
-  top_level: true
-
 api-docs:
   title: API documentation
   deployment_repo: https://github.com/RedHatInsights/api-frontend-build

--- a/main.yml
+++ b/main.yml
@@ -29,36 +29,6 @@ approval:
       - /hybrid/catalog/approval
       - /ansible/catalog/approval
 
-automation-analytics:
-  title: Automation Analytics
-  api:
-    versions:
-      - v1
-    isBeta: true
-  deployment_repo: https://github.com/RedHatInsights/tower-analytics-frontend-build.git
-  frontend:
-    paths:
-      - /ansible
-      - /ansible/automation-analytics
-
-automation-hub:
-  title: Automation Hub
-  deployment_repo: https://github.com/RedHatInsights/ansible-hub-ui-build
-  frontend:
-    paths:
-      - /ansible/automation-hub
-    sub_apps:
-      - id: ''
-        title: Collections
-        default: true
-      - id: partners
-        title: Partners
-      - id: my-namespaces
-        title: My Namespaces
-      - id: my-imports
-        title: My Imports
-  git_repo: https://github.com/ansible/ansible-hub-ui
-
 catalog:
   title: Catalog
   api:
@@ -98,45 +68,6 @@ compliance:
 config:
   title: Cloud Services Config
   deployment_repo: https://github.com/RedHatInsights/cloud-services-config
-
-cost-management:
-  title: Cost Management
-  api:
-    versions:
-      - v1
-    isBeta: true
-  channel: '#koku'
-  deployment_repo: https://github.com/RedHatInsights/cost-management-build
-  description: >
-    Cost Management is an application that provides users a view of their 
-    enterprise cost. Cost Management allows users to evaluate the cost on 
-    infrastructures like Amazon Web Services (AWS) across multiple *master* 
-    accounts, breaking down to service usage, compute usage, and storage 
-    allocation. Details can also be broken down utilizing tagging to view 
-    data attributed to project or cost center assignments. Cost Management 
-    also allows users to breakdown cost at the platform level by associating 
-    cost with OpenShift clusters, nodes, and the projects running their. Cost 
-    can be determined by deriving it from the underlying infrastructure (like 
-    AWS) or deriving it based on a user set of rates.
-  docs: https://koku.readthedocs.io/en/latest/
-  frontend:
-    paths:
-      - /hybrid/settings/cost-management/sources
-      - /hybrid/cost-management
-    sub_apps:
-      - id: ''
-        title: Overview
-        default: true
-      - id: ocp-on-aws
-        title: OpenShift on cloud details
-      - id: ocp
-        title: OpenShift details
-      - id: aws
-        title: Cloud details
-      - id: cost-models
-        title: Cost model details
-  git_repo: https://github.com/project-koku/
-  mailing_list: cost-mgmt@redhat.com
 
 dashboard:
   title: Dashboard
@@ -178,16 +109,6 @@ hooks:
     title: Hooks
     paths:
       - /settings/hooks
-
-hybrid:
-  title: Hybrid Cloud Management Services
-  frontend:
-    sub_apps:
-      - id: catalog
-      - id: cost-management
-      - id: topological-inventory
-      - id: settings-hybrid
-  top_level: true
 
 insights:
   title: Insights
@@ -238,24 +159,6 @@ migrations:
       - id: migration-analytics
         default: true
   top_level: true
-
-migration-analytics:
-  title: Migration Analytics
-  api:
-    versions:
-      - v1
-    alias:
-      - xavier
-    tags:
-      - value: "experimental"
-        title: "Experimental API"
-  deployment_repo: https://github.com/RedHatInsights/xavier-ui-deploy
-  frontend:
-    paths:
-      - /migrations
-      - /migrations/migration-analytics
-  git_repo: https://github.com/project-xavier/xavier-ui
-  mailing_list: migration-analytics-devel@redhat.com
 
 openshift:
   title: OpenShift (OCM)
@@ -336,18 +239,6 @@ settings-ansible:
       - id: rbac
     suppress_id: true
 
-settings-hybrid:
-  title: Settings
-  frontend:
-    sub_apps:
-      - id: sources
-        reload: settings/sources
-      - id: cost-management/sources
-        title: Cost Management Sources
-        reload: cost-management/sources
-      - id: rbac
-    suppress_id: true
-
 sources:
   title: Discovered Inventory
   api:
@@ -395,19 +286,6 @@ subscriptions:
     paths:
       - /staging/subscriptions
   git_repo: https://github.com/RedHatInsights/curiosity-frontend
-
-topological-inventory:
-  title: Topological Inventory
-  api:
-    versions:
-      - v1.0
-    isBeta: true
-  channel: '#insights_topology_svc'
-  deployment_repo: https://github.com/RedHatInsights/topological-inventory-frontend-build
-  frontend:
-    paths:
-      - /hybrid/topological-inventory
-
 
 vulnerability:
   title: Vulnerability Management


### PR DESCRIPTION
Removes the following apps from Stable:
- ansible bundle
- automation-analytics
- automation-hub
- cost-management
- hybrid bundle
- migration-analytics
- settings-hybrid
- topological-inventory