### PR TITLE
Ansible stable release

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -1,3 +1,12 @@
+ansible:
+  title: Red Hat Ansible Automation Platform
+  frontend:
+    sub_apps:
+      - id: automation-analytics
+        default: true
+      - id: automation-hub
+  top_level: true
+
 api-docs:
   title: API Documentation
   deployment_repo: https://github.com/RedHatInsights/api-frontend-build
@@ -18,22 +27,59 @@ approval:
       - /ansible/catalog/approval
     reload: catalog/approval
 
+automation-analytics:
+  title: Automation Analytics
+  api:
+    versions:
+      - v1
+    isBeta: true
+  deployment_repo: https://github.com/RedHatInsights/tower-analytics-frontend-build.git
+  frontend:
+    paths:
+      - /ansible
+      - /ansible/automation-analytics
+    sub_apps:
+      - id: ''
+        title: Clusters
+        default: true
+      - id: organization-statistics
+        title: Organization Statistics
+
+automation-hub:
+  title: Automation Hub
+  deployment_repo: https://github.com/RedHatInsights/ansible-hub-ui-build
+  frontend:
+    paths:
+      - /ansible/automation-hub
+    sub_apps:
+      - id: ''
+        title: Collections
+        default: true
+      - id: partners
+        title: Partners
+      - id: my-namespaces
+        title: My Namespaces
+      - id: my-imports
+        title: My Imports
+  git_repo: https://github.com/ansible/ansible-hub-ui
+
 catalog:
   title: Catalog
   api:
     versions:
       - v1
     isBeta: true
-  channel: '#insights-svc-portal'
+  channel: '#insights-catalog'
   deployment_repo: https://github.com/RedHatInsights/catalog-static-deploy
   frontend:
     paths:
-      - /hybrid/catalog
       - /ansible/catalog
     sub_apps:
+      - id: products
+        title: Products
+        default: true
       - id: portfolios
         title: Portfolios
-        default: true
       - id: platforms
         title: Platforms
       - id: orders


### PR DESCRIPTION
This merges Ansible's apps from beta to stable on prod. Catalog and Settings will continue to be deployed to prod-stable, but they will not be accessible via any navigation.

This PR addresses this Jira issue: https://projects.engineering.redhat.com/browse/RHCLOUD-2905