### PR TITLE
Remove my imports sub app from automation hub.

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -61,8 +61,6 @@ automation-hub:
         title: Partners
       - id: my-namespaces
         title: My Namespaces
-      - id: my-imports
-        title: My Imports
   git_repo: https://github.com/ansible/ansible-hub-ui
 
 catalog:


### PR DESCRIPTION
We decided to link to My Imports via internal links rather than from the main site navigation.

Part of https://github.com/ansible/galaxy-dev/issues/136