### PR TITLE
Update Subscription Reporting paths and name

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -422,7 +422,7 @@ staging:
   top_level: true
 
 subscriptions:
-  title: Subscription Reporting
+  title: Subscription Watch
   api:
     versions:
       - v1
@@ -435,7 +435,31 @@ subscriptions:
   frontend:
     paths:
       - /staging/subscriptions
+    sub_apps:
+      - id: subscriptions-rhel
   git_repo: https://github.com/RedHatInsights/curiosity-frontend
+
+subscriptions-rhel:
+  title: Red Hat Enterprise Linux
+  frontend:
+    sub_apps:
+      - id: all
+        title: All
+        reload: rhel/all
+        default: true
+      - id: arm
+        title: ARM
+        reload: rhel/arm
+      - id: ibmpower
+        title: IBM Power
+        reload: rhel/ibmpower
+      - id: ibmz
+        title: IBM Z systems
+        reload: rhel/ibmz
+      - id: x86
+        title: x86
+        reload: rhel/x86
+    suppress_id: true
 
 vulnerability:
   title: Vulnerability Management


### PR DESCRIPTION
## Description
- Updates the app name towards `Subscription watch`, and
- expands the routing

## Relates to
Parallel task to #93 

## Open questions/guidance
Have additional questions regarding the implementation of ...

1. Was unsure of the naming scheme associated with the tiered menu structure, please advise if there is a specific ID for `subscriptions-rhel` that would be preferred?
2. It's been requested that there should be a `Getting Started` and `Documentation` set of links, similar to the below. I'm unfamiliar with that process, is that a setting controlled from `main.yml`?
   - https://github.com/RedHatInsights/curiosity-frontend/issues/129
   - https://github.com/RedHatInsights/curiosity-frontend/issues/130

![Screen Shot 2019-11-15 at 3 36 12 PM](https://user-images.githubusercontent.com/3761375/68976180-3d7f6e00-07c3-11ea-8373-02dccdd8284e.png)

@kruai @ryelo @karelhala 