### PR TITLE
Remove system patch manager from prod-beta

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -362,7 +362,6 @@ rhel:
       - id: vulnerability
       - id: compliance
       - id: drift
-      - id: patch
       - id: inventory
       - id: remediations
   top_level: true


### PR DESCRIPTION
> hey Ryan, Shane McDowell noted prod beta contains 'System Patch Manager' menu item ... and this is not expected ... since jdostal is on PTO today and tomorrow, is there any chance someone from your team could undo the menu item, please?

