### PR TITLE
Add sub-apps for compliance

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -104,6 +104,7 @@ compliance:
   api:
     versions:
       - v1
+    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/compliance-frontend-build
   frontend:
     paths:

--- a/main.yml
+++ b/main.yml
@@ -110,16 +110,13 @@ compliance:
     paths:
       - /rhel/compliance
     sub_apps:
-      - id: ''
+      - id:
         title: Reports
         default: true
-        reload: compliance
       - id: policies
         title: Policies
-        reload: compliance/policies
       - id: systems
         title: Systems
-        reload: compliance/systems
 
 config:
   title: Cloud Services Config

--- a/main.yml
+++ b/main.yml
@@ -110,7 +110,7 @@ compliance:
     paths:
       - /rhel/compliance
     sub_apps:
-      - id:
+      - id: ''
         title: Reports
         default: true
       - id: policies

--- a/main.yml
+++ b/main.yml
@@ -108,6 +108,17 @@ compliance:
   frontend:
     paths:
       - /rhel/compliance
+    sub_apps:
+      - id: ''
+        title: Reports
+        default: true
+        reload: compliance
+      - id: policies
+        title: Policies
+        reload: compliance/policies
+      - id: systems
+        title: Systems
+        reload: compliance/systems
 
 config:
   title: Cloud Services Config


### PR DESCRIPTION
We were asked to split the app into Reports, Policies and Systems. However Policies will not be available in QA and prod for a while, how should we work around that?

This PR introduces "policies" - https://github.com/RedHatInsights/compliance-frontend/pull/197