### PR TITLE
Products should always be visible

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -106,10 +106,6 @@ catalog:
     sub_apps:
       - id: products
         title: Products
-        permissions:
-          method: hasPermissions
-          args:
-            - [catalog:portfolios:create]
       - id: portfolios
         title: Portfolios
         default: true


### PR DESCRIPTION
Only Platforms was meant to be hidden.  (The wording was confusing.)

Reverts one of the links from https://github.com/RedHatInsights/cloud-services-config/pull/120

cc @Hyperkid123 