### PR TITLE
Add Migration Analytics available in CI-STABLE

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -213,6 +213,32 @@ landing:
   channel: '#flip-mode-squad'
   deployment_repo: https://github.com/RedHatInsights/landing-page-frontend-build
 
+migrations:
+  title: Migrations
+  frontend:
+    sub_apps:
+      - id: migration-analytics
+        default: true
+  top_level: true
+
+migration-analytics:
+  title: Migration Analytics
+  api:
+    versions:
+      - v1
+    alias:
+      - xavier
+    tags:
+      - value: "experimental"
+        title: "Experimental API"
+  deployment_repo: https://github.com/RedHatInsights/xavier-ui-deploy
+  frontend:
+    paths:
+      - /migrations
+      - /migrations/migration-analytics
+  git_repo: https://github.com/project-xavier/xavier-ui
+  mailing_list: migration-analytics-devel@redhat.com
+
 openshift:
   title: OpenShift (OCM)
   api:


### PR DESCRIPTION
Right now Migration analytics is available in ci-beta, qa-beta, and prod-beta environments but now we need also ci-stable.

- The configuration will be the same as qa-beta unless there is any inconvenient with it