### PR TITLE
Updated Cost Management details navigation

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -184,20 +184,25 @@ cost-management:
         title: Overview
         default: true
         group: cost-management
-      - id: ocp-cloud
-        title: OpenShift cloud infrastructure details
-        group: cost-management
-      - id: ocp
-        title: OpenShift details
-        group: cost-management
-      - id: aws
-        title: Cloud details
+      - id: details
         group: cost-management
       - id: cost-models
         title: Cost models
         group: cost-management
   git_repo: https://github.com/project-koku/
   mailing_list: cost-mgmt@redhat.com
+
+details:
+  title: Details
+  frontend:
+    paths:
+      - /cost-management/details
+    sub_apps:
+      - id: ocp
+        title: OpenShift
+        default: true
+      - id: infrastructure
+        title: Infrastructure
 
 policies:
   title: Policies


### PR DESCRIPTION
Updated Cost Management details navigation to look like this mock:

<img width="290" alt="Screen Shot 2020-03-18 at 2 05 00 PM" src="https://user-images.githubusercontent.com/17481322/76993486-4922a300-6923-11ea-9f27-e365d2ba1170.png">

See https://projects.engineering.redhat.com/browse/RHCLOUD-5267

Note: this is needed for the prod release on 4/23 -- our code freeze is 3/30