### PR TITLE
Remove mailing_list field from migration-analytics

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -324,7 +324,6 @@ migration-analytics:
       - /migrations
       - /migrations/migration-analytics
   git_repo: https://github.com/project-xavier/xavier-ui
-  mailing_list: migration-analytics-devel@redhat.com
 
 openshift:
   title: OpenShift (OCM)


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-430

The Pentesting of the Migration Analytics application has discovered a hardcoded e-mail address and they have recommended it is removed... The only place where I know we are hardcoding our email is in this repository, so I'd like to remove it, please.