### PR TITLE
Only Org Admins can change Cost Management Application Settings

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -50,6 +50,7 @@ applications:
           method: isEntitled
           args:
             - cost_management
+          method: isOrgAdmin
     paths:
       - /settings/applications
 


### PR DESCRIPTION
We want only entitled org_admin users to be able to alter cost management settings.

@karelhala Can you take a look and verify that my change works as described?