### PR TITLE
Add Migration Analytics available in QA-STABLE

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -211,6 +211,31 @@ landing:
   channel: '#flip-mode-squad'
   deployment_repo: https://github.com/RedHatInsights/landing-page-frontend-build
 
+migrations:
+  title: Migrations
+  frontend:
+    sub_apps:
+      - id: migration-analytics
+        default: true
+  top_level: true
+
+migration-analytics:
+  title: Migration Analytics
+  api:
+    versions:
+      - v1
+    alias:
+      - xavier
+    tags:
+      - value: "experimental"
+        title: "Experimental API"
+  deployment_repo: https://github.com/RedHatInsights/xavier-ui-deploy
+  frontend:
+    paths:
+      - /migrations
+      - /migrations/migration-analytics
+  git_repo: https://github.com/project-xavier/xavier-ui
+
 openshift:
   title: OpenShift (OCM)
   api:


### PR DESCRIPTION
Migration Analytics needs to be in `qa-stable` too. The configuration will be the same as the other environments.