### PR TITLE
Show Cost Mgmt Settings for entitled org admin

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -36,6 +36,10 @@ api-docs:
 applications:
   title: Applications
   deployment_repo: https://github.com/RedHatInsights/settings-frontend-build
+  permissions:
+    method: isOrgAdmin
+    apps:
+      - cost-management
   frontend:
     sub_apps:
       - id: insights
@@ -47,7 +51,9 @@ applications:
       - id: cost-management
         title: Cost Management
         permissions:
-          method: isOrgAdmin
+          method: isEntitled
+          args:
+            - cost_management
     paths:
       - /settings/applications
 


### PR DESCRIPTION
Make @karelhala update to support app settings for cost management only visible for entitled org admin users:
https://github.com/RedHatInsights/cloud-services-config/pull/144#issuecomment-605990375