### PR TITLE
Update ID for cost-management details

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -205,7 +205,7 @@ details:
       - id: ocp
         title: OpenShift
         default: true
-      - id: infrastructure
+      - id: aws
         title: Infrastructure
 
 policies:


### PR DESCRIPTION
Updated ID for cost-management details link. Tested locally.

This eliminates a "not found" message, which is briefly seen before redirecting to our default page. This small change will allow us to navigate directly to our default page instead of relying on a redirect.

Related to https://projects.engineering.redhat.com/browse/RHCLOUD-5267

Note: this is needed for our code freeze on 4/1 -- prod release on 4/23.