### PR TITLE
Removed "paths" from cost-management details

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -199,8 +199,6 @@ cost-management:
 details:
   title: Details
   frontend:
-    paths:
-      - /cost-management/details
     sub_apps:
       - id: ocp
         title: OpenShift


### PR DESCRIPTION
Removed "paths" from cost-management `details`. Tested locally.

This mimics Subscription Watch’s `rhel-sw` secondary nav