### PR TITLE
Remove 'default' from cost-management details

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -202,7 +202,6 @@ details:
     sub_apps:
       - id: ocp
         title: OpenShift
-        default: true
       - id: aws
         title: Infrastructure
 


### PR DESCRIPTION
Removed 'default' from cost-management details. This appears to redirect to ocp upon a page refresh