### PR TITLE
Cost Management details links not highlighted

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -204,10 +204,9 @@ details:
     sub_apps:
       - id: ocp
         title: OpenShift
-        group: cost-management
       - id: aws
+        default: true
         title: Infrastructure
-        group: cost-management
 
 policies:
   title: Policies


### PR DESCRIPTION
The Cost Management details links are not highlighted properly.

To see the issue, navigate to Cost Management > Details > Infrastructure

1.  Select Azure from the tertiary nav. The Details > Infrastructure link is no longer highlighted.
2. While still on Azure, refresh the page. Now the Details > OpenShift link is highlighted.

This small change fixes both issues.