### PR TITLE
Remove beta flag from RBAC api (#174)

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -300,7 +300,6 @@ rbac:
   api:
     versions:
       - v1
-    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/rbac-frontend-deploy.git
   frontend:
     title: User access


### PR DESCRIPTION
Do the same thing for ci-stable