### PR TITLE
Add ID to compliance/reports

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -158,7 +158,7 @@ compliance:
     paths:
       - /insights/compliance
     sub_apps:
-      - id: ''
+      - id: reports
         title: Reports
         default: true
       - id: scappolicies


### PR DESCRIPTION
In order to move to it through `insights.chrome.appNavClick` we need to have an ID for Compliance 'reports'.

This should go in all environments please :pray: .

This is a requirement to complete https://github.com/RedHatInsights/compliance-frontend/pull/576