### PR TITLE
Add 'Overview' link to Openshift Cluster Manager

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -373,6 +373,9 @@ openshift:
       - id: subscriptions
         title: Subscriptions
         group: openshift
+      - id: overview
+        title: Overview
+        group: openshift
   source_repo: 
   top_level: true
 


### PR DESCRIPTION
This link should **only** be shown in qaprodauth.redhat.com/.

cc: @elad661 @egilma