### PR TITLE
[prod-beta] Add ID to compliance/reports (#204)

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -156,7 +156,7 @@ compliance:
     paths:
       - /insights/compliance
     sub_apps:
-      - id: ''
+      - id: reports
         title: Reports
         default: true
       - id: scappolicies


### PR DESCRIPTION
In order to move to it through `insights.chrome.appNavClick` we need to have an ID for Compliance 'reports'