### PR TITLE
Change redirect to API docs to be just api instead repeating docs

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -247,7 +247,7 @@ docs:
   frontend:
     sub_apps:
       - id: api-docs
-        reload: docs/api
+        reload: api
         default: true
   top_level: true
 


### PR DESCRIPTION
This fixes a bug that one of our customers reported and Rob old us about a few days back.