### PR TITLE
Change reload for app settings of advisor

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -50,7 +50,7 @@ applications:
           method: isEntitled
           args:
             - insights
-        reload: applications/insights
+        reload: applications/advisor
       - id: cost-management
         title: Cost Management
         permissions:


### PR DESCRIPTION
This reload is meesing our URL, it looks like `/settings/applications/insights` whereas it should be `/settings/applications/advisor`. It also messed up the title of settings card, because it uses `insights` props instead of `advisor` ones.