### PR TITLE
⬆ image-builder: Move above inventory

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -365,10 +365,10 @@ insights:
       - id: patch
       - id: drift
       - id: policies
+      - id: image-builder
       - id: inventory
       - id: remediations
       - id: registration
-      - id: image-builder
   top_level: true
 
 inventory:


### PR DESCRIPTION
Move image-builder between policies and inventory per an email
conversation with UXD.

Signed-off-by: Major Hayden <major@redhat.com>