### PR TITLE
Convert internal bundle sub_apps to an array.

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -377,8 +377,8 @@ internal:
   top_level: true
   frontend:
     sub_apps:
-      id: commit-tracker
-      default: true
+      - id: commit-tracker
+        default: true
 
 inventory:
   title: Managed Inventory


### PR DESCRIPTION
The internal bundle sub-apps definition was an object instead of an array. This caused the chrome navigation to crash because of incorrect format.

Just a thought. Should we create a simple validator to prevent these kinds of issues?

cc @karelhala @ryelo 