### PR TITLE
🔃 Update image-builder-frontend-build location

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -349,7 +349,7 @@ frontend-assets:
 
 image-builder:
   title: Image Builder
-  deployment_repo: https://github.com/osbuild/image-builder-frontend-build
+  deployment_repo: https://github.com/RedHatInsights/image-builder-frontend-build
   frontend:
     paths:
       - /insights/image-builder


### PR DESCRIPTION
The image-builder-frontend-build repository lives in the redhatinsights org now.

Signed-off-by: Major Hayden <major@redhat.com>