### PR TITLE
[prod-stable] Refactored Cost Management navigation

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -215,7 +215,10 @@ cost-management:
         title: Overview
         default: true
         group: cost-management
-      - id: details
+      - id: ocp
+        title: OpenShift
+        group: cost-management
+      - id: infrastructure
         group: cost-management
       - id: cost-models
         title: Cost Models
@@ -223,14 +226,15 @@ cost-management:
   source_repo: https://github.com/project-koku/
   mailing_list: cost-mgmt@redhat.com
 
-details:
-  title: Details
+infrastructure:
+  title: Infrastructure
   frontend:
     sub_apps:
-      - id: ocp
-        title: OpenShift
       - id: aws
-        title: Infrastructure
+        title: Amazon Web Services
+        default: true
+      - id: azure
+        title: Microsoft Azure
 
 dashboard:
   title: Dashboard
@@ -389,7 +393,7 @@ openshift:
       - id: overview
         title: Overview
         group: openshift
-  source_repo: 
+  source_repo:
   top_level: true
 
 patch:
@@ -567,7 +571,7 @@ trust:
     paths:
       - /security/insights
   source_repo: https://github.com/RedHatInsights/trust-frontend
-  
+
 user-preferences:
   title: User Preferences
   deployment_repo: https://github.com/RedHatInsights/user-preferences-frontend-build


### PR DESCRIPTION
Under the "Details" item in the Insights navigation pane, we currently have "OpenShift" and "Infrastructure" options. We want to remove the "Details" items the nav and move its contents one level higher.

Mock: https://marvelapp.com/prototype/9404edb/screen/73884272

<img width="1646" alt="Screen Shot 2020-10-26 at 10 31 43 AM" src="https://user-images.githubusercontent.com/17481322/97188103-8680c600-1779-11eb-8cf1-71c03cf310b3.png">