### PR TITLE
[prod-beta] Refactored Cost Management navigation

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -216,7 +216,10 @@ cost-management:
         title: Overview
         default: true
         group: cost-management
-      - id: details
+      - id: ocp
+        title: OpenShift
+        group: cost-management
+      - id: infrastructure
         group: cost-management
       - id: cost-models
         title: Cost models
@@ -224,14 +227,15 @@ cost-management:
   source_repo: https://github.com/project-koku/
   mailing_list: cost-mgmt@redhat.com
 
-details:
-  title: Details
+infrastructure:
+  title: Infrastructure
   frontend:
     sub_apps:
-      - id: ocp
-        title: OpenShift
       - id: aws
-        title: Infrastructure
+        title: Amazon Web Services
+        default: true
+      - id: azure
+        title: Microsoft Azure
 
 policies:
   title: Policies
@@ -580,7 +584,7 @@ trust:
     paths:
       - /security/insights
   source_repo: https://github.com/RedHatInsights/trust-frontend
-  
+
 user-preferences:
   title: User preferences
   deployment_repo: https://github.com/RedHatInsights/user-preferences-frontend-build


### PR DESCRIPTION
Under the "Details" item in the Insights navigation pane, we currently have "OpenShift" and "Infrastructure" options. We want to remove the "Details" items the nav and move its contents one level higher.

Mock: https://marvelapp.com/prototype/9404edb/screen/73884272

<img width="1646" alt="Screen Shot 2020-10-26 at 10 31 43 AM" src="https://user-images.githubusercontent.com/17481322/97188103-8680c600-1779-11eb-8cf1-71c03cf310b3.png">