### PR TITLE
[qa-stable] Refactored Cost Management navigation

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -214,7 +214,10 @@ cost-management:
         title: Overview
         default: true
         group: cost-management
-      - id: details
+      - id: ocp
+        title: OpenShift
+        group: cost-management
+      - id: infrastructure
         group: cost-management
       - id: cost-models
         title: Cost Models
@@ -222,14 +225,15 @@ cost-management:
   source_repo: https://github.com/project-koku/
   mailing_list: cost-mgmt@redhat.com
 
-details:
-  title: Details
+infrastructure:
+  title: Infrastructure
   frontend:
     sub_apps:
-      - id: ocp
-        title: OpenShift
       - id: aws
-        title: Infrastructure
+        title: Amazon Web Services
+        default: true
+      - id: azure
+        title: Microsoft Azure
 
 dashboard:
   title: Dashboard


### PR DESCRIPTION
Under the "Details" item in the Insights navigation pane, we currently have "OpenShift" and "Infrastructure" options. We want to remove the "Details" items the nav and move its contents one level higher.

Mock: https://marvelapp.com/prototype/9404edb/screen/73884272

<img width="1646" alt="Screen Shot 2020-10-26 at 10 31 43 AM" src="https://user-images.githubusercontent.com/17481322/97188103-8680c600-1779-11eb-8cf1-71c03cf310b3.png">