### PR TITLE
Add app_base to schema validator.

### DIFF
--- a/validate-yaml.js
+++ b/validate-yaml.js
@@ -10,6 +10,7 @@ const permissionsSchema = Joi.object({
 
 const frontendSchema = Joi.object({
     title: Joi.string(),
+    app_base: Joi.string(),
     reload: Joi.string(),
     paths: Joi.array().items(Joi.string()),
     sub_apps: Joi.array().items(Joi.object({


### PR DESCRIPTION
Fixes the invalid attribute app_base.

unblocks: #315 

cc @pmuir @karelhala 