### PR TITLE
Remove reload from drift endpoints

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -292,10 +292,8 @@ drift:
       - id: ''
         title: Comparison
         default: true
-        reload: drift
       - id: baselines
         title: Baselines
-        reload: drift/baselines
   source_repo: https://github.com/RedHatInsights/drift-frontend
 
 edge:


### PR DESCRIPTION
### Reload not needed for drift apps

@johnsonm325 requested to fix an extra reload when switching from one drift enpoint to another. This PR does such thing by removing the reload partial of drift frontend apps.