### PR TITLE
Drift title wrong in API docs

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -268,7 +268,7 @@ docs:
   top_level: true
 
 drift:
-  title: Configuration Drift
+  title: Drift
   api:
     subItems:
       drift:


### PR DESCRIPTION
This should just be Drift

![image](https://user-images.githubusercontent.com/12520842/104609825-71695400-5651-11eb-848d-b87c3cf2a7c2.png)
