### PR TITLE
Remove source provider requirement for Cost Management

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -243,11 +243,6 @@ cost-management:
             args:
               - url: '/api/cost-management/v1/user-access/?type=OCP'
                 accessor: 'data'
-          - method: apiRequest
-            args:
-              - url: '/api/cost-management/v1/sources/?type=OCP'
-                matcher: 'isNotEmpty'
-                accessor: 'data'
       - id: infrastructure
         group: cost-management
       - id: cost-models
@@ -352,11 +347,6 @@ infrastructure:
             args:
               - url: '/api/cost-management/v1/user-access/?type=AWS'
                 accessor: 'data'
-          - method: apiRequest
-            args:
-              - url: '/api/cost-management/v1/sources/?type=AWS'
-                matcher: 'isNotEmpty'
-                accessor: 'data'
       - id: azure
         title: Microsoft Azure
         permissions:
@@ -364,22 +354,12 @@ infrastructure:
             args:
               - url: '/api/cost-management/v1/user-access/?type=AZURE'
                 accessor: 'data'
-          - method: apiRequest
-            args:
-              - url: '/api/cost-management/v1/sources/?type=AZURE'
-                matcher: 'isNotEmpty'
-                accessor: 'data'
       - id: gcp
         title: Google Cloud Provider
         permissions:
           - method: apiRequest
             args:
               - url: '/api/cost-management/v1/user-access/?type=GCP'
-                accessor: 'data'
-          - method: apiRequest
-            args:
-              - url: '/api/cost-management/v1/sources/?type=GCP'
-                matcher: 'isNotEmpty'
                 accessor: 'data'
 
 ingress:


### PR DESCRIPTION
After some testing, the Cost Management team prefers the visible Insights nav links to be based on RBAC permissions only. Thus, if users don't have a source provider, our details pages would still be available to show an empty state, which directs them to the settings page. That is, providing they have RBAC permissions to see the page.

https://issues.redhat.com/browse/COST-943

<img width="1408" alt="insights-qa user" src="https://user-images.githubusercontent.com/17481322/106071656-b8852980-60d4-11eb-813f-50f3d20dac6e.png">
