### PR TITLE
Historical Cost Explorer link (ci-stable)

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -324,7 +324,7 @@ infrastructure:
               - url: '/api/cost-management/v1/user-access/?type=AZURE'
                 accessor: 'data'
       - id: gcp
-        title: Google Cloud Provider
+        title: Google Cloud Platform
         permissions:
           - method: apiRequest
             args:

--- a/main.yml
+++ b/main.yml
@@ -234,6 +234,14 @@ cost-management:
             args:
               - url: '/api/cost-management/v1/user-access/?type=cost_model'
                 accessor: 'data'
+      - id: explorer
+        title: Historical Cost Explorer
+        group: cost-management
+        permissions:
+          - method: apiRequest
+            args:
+              - url: '/api/cost-management/v1/user-access/?type=any&beta=true'
+                accessor: 'data'
   source_repo: https://github.com/project-koku/
   mailing_list: cost-mgmt@redhat.com
 


### PR DESCRIPTION
Added a "Historical Cost Explorer" navigation link to Cost Management.

https://issues.redhat.com/browse/COST-979