### PR TITLE
GCP as beta only feature (qa-stable)

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -334,7 +334,7 @@ infrastructure:
         permissions:
           - method: apiRequest
             args:
-              - url: '/api/cost-management/v1/user-access/?type=GCP'
+              - url: '/api/cost-management/v1/user-access/?type=GCP&beta=true'
                 accessor: 'data'
 
 ingress:


### PR DESCRIPTION
https://issues.redhat.com/browse/COST-1016

It was requested that we make Google Cloud Platform a beta only feature. That is, until GCP can be added via platform sources.

To do this, we need to change the Insights navigation and call our `user-access` API with the `beta=true` flag. This will hide the GCP nav link from the stage and prod environments.