### PR TITLE
Use complex module definition for edge and api-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To indicate which module should be loaded when rendering your app (you can have 
 
 ##### app_id.frontend.module.group
 
-If you have first level application to indicate which group should be managed by this module.
+If you have a first-level application, this field indicates which group should be managed by this module.
 
 #### app_id.frontend.paths
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ To indicate federated modules scope of your application (you can have multiple s
 
 To indicate which module should be loaded when rendering your app (you can have multiple modules per one scope). This is usually `./RootApp`
 
+##### app_id.frontend.module.group
+
+If you have first level application to indicate which group should be managed by this module.
+
 #### app_id.frontend.paths
 
 This is the list of URL paths where your app will be located.

--- a/main.yml
+++ b/main.yml
@@ -45,7 +45,11 @@ api-docs:
   title: API Documentation
   deployment_repo: https://github.com/RedHatInsights/api-frontend-build
   frontend:
-    module: apiDocs#./RootApp
+    module:
+      appName: api-docs
+      scope: apiDocs
+      module: ./RootApp
+      group: docs
     paths:
       - /docs/api
       - /docs
@@ -296,7 +300,6 @@ dashboard:
   channel: '#advisor'
   deployment_repo: https://github.com/RedHatInsights/insights-dashboard-build
   frontend:
-    module: dashboard#./RootApp
     paths:
       - /insights
       - /insights/dashboard
@@ -350,7 +353,11 @@ edge:
   source_repo: https://github.com/RedHatInsights/edge-frontend
   top_level: true
   frontend:
-    module: edge#./RootApp
+    module:
+      appName: edge
+      scope: edge
+      module: ./RootApp
+      group: groups
     title: Edge for RHEL
     paths:
       - /edge
@@ -707,9 +714,6 @@ rhel-sw:
 
 ros:
   title: Resource Optimization
-  api:
-    versions:
-      - v0
   channel: '#team-ros'
   deployment_repo: https://github.com/RedHatInsights/ros-frontend-build
   frontend:

--- a/main.yml
+++ b/main.yml
@@ -714,6 +714,9 @@ rhel-sw:
 
 ros:
   title: Resource Optimization
+  api:
+    versions:
+      - v0
   channel: '#team-ros'
   deployment_repo: https://github.com/RedHatInsights/ros-frontend-build
   frontend:

--- a/validate-yaml.js
+++ b/validate-yaml.js
@@ -11,7 +11,8 @@ const permissionsSchema = Joi.object({
 const moduleSchema = Joi.object({
     module: Joi.string(),
     scope: Joi.string(),
-    appName: Joi.string()
+    appName: Joi.string(),
+    group: Joi.string()
 });
 
 const frontendSchema = Joi.object({


### PR DESCRIPTION
#### No app loading for edge and api-docs

Currently no app is being loaded in edge or api-docs because of first level navigation. This PR changes the module definition for these 2 apps so it uses complex module definition so we can use all partials.