### PR TITLE
Add modules to main.yml and add validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyc
 
 akamai/venv/**/*
+
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+  - node
+before_install:
+  - npm install -g npm@latest
+install:
+  - npm ci
+jobs:
+  include:
+    - stage: validate
+      script: npm run validate-yaml
+cache:
+  directories:
+    - "$HOME/.npm"
+    - ".cache"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Here is some example configuration that demonstrates the structure, using all re
     deployment_repo: https://github.com/app-deployment-repo-url
     disabled_on_prod: true
     docs: https://link.to.docs.com/docs
+    permissions:
+        method: isOrgAdmin
+        apps:
+            - app_id_1
     frontend:
         title: App Title Override
         paths:
@@ -35,6 +39,10 @@ Here is some example configuration that demonstrates the structure, using all re
             -   id: app_id_1
                 title: Some Sub App
                 default: true
+                permissions:
+                    method: isEntitled
+                    args:
+                        - insights
             -   id: app_id_2
                 title: Another Sub App
         suppress_id: true
@@ -86,6 +94,26 @@ If you want the name of your app to appear differently on the frontend, set this
 #### app_id.frontend.app_base
 
 If you want this app to use the same codebase as another existing app, set this value to the ID of that app.
+
+#### app_id.frontend.module
+
+To indicate chrome how to load the application for federated modules you need to pass this property. It can either be a magic link containing `yourApp#./RootApp` for most applications. If you want to be more specific you can pass in module object containing `appName`, `scope` and `module`
+
+##### app_id.frontend.module.appName
+
+To indicate chrome loader from what app to load your fed-mods config.
+
+##### app_id.frontend.module.scope
+
+To indicate federated modules scope of your application (you can have multiple scopes per one app). This is usually your application's name (same as `appName`).
+
+##### app_id.frontend.module.module
+
+To indicate which module should be loaded when rendering your app (you can have multiple modules per one scope). This is usually `./RootApp`
+
+##### app_id.frontend.module.group
+
+If you have a first-level application, this field indicates which group should be managed by this module.
 
 #### app_id.frontend.paths
 
@@ -142,6 +170,18 @@ This is the mailing list associated with your project. Used to automate email no
 
 If this is set to `true`, your app will be a top-level app, which is usually reserved for bundles (Insights, RHEL, Hybrid, Openshift, etc).
 Use this if your app does not have a parent app or bundle.
+
+#### permissions.method
+
+If you want to hide any navigational element based on some chrome's logic, this is the right property. This defines the function to be used in order to hide nav item. (Chrome's list of methods)[https://github.com/RedHatInsights/insights-chrome#permissions].
+
+#### permissions.args
+
+If the `permissions.method` requires some arguments in order to properly work, this is how to pass them to it: an array of items.
+
+#### permissions.apps
+
+If you want to control visibility for multiple navigation items you can specify one permission per entry and list which apps from `frontend.sub_apps` should be checked.
 
 ## Akamai API Access
 

--- a/main.yml
+++ b/main.yml
@@ -7,6 +7,7 @@ advisor:
   channel: '#advisor'
   deployment_repo: https://github.com/RedHatInsights/insights-advisor-frontend-build
   frontend:
+    module: advisor#./RootApp
     paths:
       - /insights/advisor
     sub_apps:
@@ -19,7 +20,7 @@ advisor:
   source_repo: https://github.com/RedHatInsights/insights-advisor-frontend
 
 ansible:
-  title: Red Hat Ansible Automation Platform
+  title: Ansible Automation Platform
   frontend:
     sub_apps:
       - id: automation-analytics
@@ -32,6 +33,11 @@ api-docs:
   title: API Documentation
   deployment_repo: https://github.com/RedHatInsights/api-frontend-build
   frontend:
+    module:
+      appName: api-docs
+      scope: apiDocs
+      module: ./RootApp
+      group: docs
     paths:
       - /docs/api
       - /docs
@@ -97,7 +103,6 @@ automation-analytics:
       - id: automation-calculator
         title: Automation calculator
   source_repo: https://github.com/RedHatInsights/tower-analytics-frontend
-
 
 automation-hub:
   title: Automation Hub
@@ -171,6 +176,7 @@ compliance:
       - v1
   deployment_repo: https://github.com/RedHatInsights/compliance-frontend-build
   frontend:
+    module: compliance#./RootApp
     paths:
       - /insights/compliance
     sub_apps:
@@ -288,6 +294,7 @@ drift:
         title: Historical system profiles
   deployment_repo: https://github.com/RedHatInsights/drift-frontend-build
   frontend:
+    module: drift#./RootApp
     title: Drift
     paths:
       - /insights/drift
@@ -353,7 +360,7 @@ ingress:
 insights:
   title: Insights
   frontend:
-    title: Red Hat Insights
+    title: Insights
     sub_apps:
       - id: dashboard
         default: true
@@ -377,6 +384,7 @@ inventory:
   channel: '#flip-mode-squad'
   deployment_repo: https://github.com/RedHatInsights/insights-inventory-frontend-build
   frontend:
+    module: inventory#./RootApp
     title: Inventory
     paths:
       - /insights/inventory
@@ -428,7 +436,7 @@ openshift:
       - v1
   deployment_repo: https://github.com/RedHatInsights/uhc-portal-frontend-deploy.git
   frontend:
-    title: Red Hat OpenShift Cluster Manager
+    title: OpenShift Cluster Manager
     paths:
       - /openshift
     sub_apps:
@@ -439,7 +447,6 @@ openshift:
       - id: subscriptions
         title: Subscriptions
         group: openshift
-  source_repo:
   top_level: true
 
 patch:
@@ -450,6 +457,7 @@ patch:
   channel: '#team-patchman'
   deployment_repo: https://github.com/RedHatInsights/patchman-ui-build
   frontend:
+    module: patch#./RootApp
     title: Patch
     paths:
       - /insights/patch
@@ -484,6 +492,7 @@ rbac:
   permissions:
     method: isOrgAdmin
   frontend:
+    module: rbac#./RootApp
     title: User access
     paths:
       - /settings/rbac
@@ -514,6 +523,7 @@ remediations:
   channel: '#insights-remediations'
   deployment_repo: https://github.com/RedHatInsights/insights-remediations-frontend-build
   frontend:
+    module: remediations#./RootApp
     paths:
       - /insights/remediations
   source_repo: https://github.com/RedHatInsights/insights-remediations-frontend
@@ -657,6 +667,7 @@ vulnerability:
   channel: '#team-vulnerability'
   deployment_repo: https://github.com/RedHatInsights/vulnerability-ui-build
   frontend:
+    module: vulnerability#./RootApp
     title: Vulnerability
     paths:
       - /insights/vulnerability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "cloud-services-config",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@hapi/hoek": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/address": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
+      "integrity": "sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "joi": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "cloud-services-config",
+  "version": "0.0.0",
+  "description": "This repo deals with the high-level configuration of Cloud Services. `main.yml` contains the source of truth for CS apps, and the `akamai` folder deals with updating our Akamai configuration.",
+  "main": "index.js",
+  "scripts": {
+    "validate-yaml": "node validate-yaml.js"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "joi": "^17.2.1",
+    "js-yaml": "^3.14.0"
+  }
+}

--- a/validate-yaml.js
+++ b/validate-yaml.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const {load} = require('js-yaml');
+const Joi = require('joi');
+
+const permissionsSchema = Joi.object({
+    method: Joi.string().required(),
+    apps: Joi.array().items(Joi.string()),
+    args: Joi.array().items(Joi.any())
+})
+
+const moduleSchema = Joi.object({
+    module: Joi.string(),
+    scope: Joi.string(),
+    appName: Joi.string(),
+    group: Joi.string()
+});
+
+const frontendSchema = Joi.object({
+    title: Joi.string(),
+    app_base: Joi.string(),
+    reload: Joi.string(),
+    paths: Joi.array().items(Joi.string()),
+    module: [Joi.string(), moduleSchema],
+    sub_apps: Joi.array().items(Joi.object({
+        id: Joi.string().required().allow(''),
+        default: Joi.boolean(),
+        title: Joi.string(),
+        group: Joi.string(),
+        reload: Joi.string(),
+        permissions: [Joi.array().items(permissionsSchema), permissionsSchema]
+    }))
+})
+
+const schema = Joi.object({
+    disabled_on_prod: Joi.boolean(),
+    description: Joi.string(),
+    docs: Joi.string(),
+    mailing_list: Joi.string(),
+    title: Joi.string(),
+    api: Joi.object({
+        apiName: Joi.string(),
+        versions: [Joi.array().items(Joi.string()), Joi.string()],
+        isBeta: Joi.boolean(),
+        alias: Joi.array().items(Joi.string()),
+        subItems: Joi.object().pattern(/^/ ,Joi.object({
+            versions: [Joi.array().items(Joi.string()), Joi.string()],
+            title: Joi.string()
+        })),
+        tags: Joi.array().items(Joi.object({
+            value: Joi.string().required(),
+            title: Joi.string().required()
+        }))
+    }),
+    channel: Joi.string(),
+    deployment_repo: Joi.string(),
+    source_repo: Joi.string(),
+    frontend: frontendSchema,
+    top_level: Joi.boolean(),
+    permissions: [Joi.array().items(permissionsSchema), permissionsSchema]
+})
+
+const inputfile = 'main.yml';
+const structure = load(fs.readFileSync(inputfile, { encoding: 'utf-8' }));
+
+async function validate() {
+    Object.entries(structure).forEach(async ([ key, value ]) => {
+        try {
+            const result = await schema.validateAsync(value);
+        } catch (error) {
+            console.error(`Error in ${key} app definition.\n`, error)
+            process.exit(1)
+        }
+    })
+}
+
+validate()


### PR DESCRIPTION
### Add modules

If someone is running chrome and migrated app locally they could experience problems with missing module config. This PR adds the module definitions to each of migrated app, so once the chrome lands in the ci-stable all migrated apps will start to use it.

### Add validation

Since we want to have validation on ci-stable same as is on ci-beta this PR adds package.json and the required configs.