### PR TITLE
fix(starter): add starter app to ci-beta

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -457,6 +457,7 @@ insights:
       - id: remediations
       - id: registration
       - id: ros
+      - id: starter
   top_level: true
 
 integrations:
@@ -807,6 +808,20 @@ staging:
       - id: ruledev
       - id: policies
   top_level: true
+
+starter:
+  title: Starter
+  api:
+    versions:
+      - v1
+    apiName: insights
+  channel: '#forum-clouddot-ui'
+  deployment_repo: https://github.com/RedHatInsights/frontend-starter-app-build
+  frontend:
+    module: starter#./RootApp
+    paths:
+      - /insights/starter
+  source_repo: https://github.com/RedHatInsights/frontend-starter-app
 
 storybook:
   channel: '#flip-mode-squad'

--- a/main.yml
+++ b/main.yml
@@ -457,7 +457,6 @@ insights:
       - id: remediations
       - id: registration
       - id: ros
-      - id: starter
   top_level: true
 
 integrations:
@@ -805,6 +804,7 @@ staging:
   title: Staging Bundle
   frontend:
     sub_apps:
+      - id: starter
       - id: ruledev
       - id: policies
   top_level: true
@@ -820,7 +820,7 @@ starter:
   frontend:
     module: starter#./RootApp
     paths:
-      - /insights/starter
+      - /staging/starter
   source_repo: https://github.com/RedHatInsights/frontend-starter-app
 
 storybook:


### PR DESCRIPTION
Add the starter app so that forks of https://github.com/RedHatInsights/frontend-starter-app don't have to change `main.yml` before testing their apps.