### PR TITLE
Rename "Historical Cost Explorer" link (ci-stable)

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -246,7 +246,7 @@ cost-management:
               - url: '/api/cost-management/v1/user-access/?type=cost_model'
                 accessor: 'data'
       - id: explorer
-        title: Historical Cost Explorer
+        title: Cost Explorer
         group: cost-management
         permissions:
           - method: apiRequest


### PR DESCRIPTION
Renames "Historical Cost Explorer" link as "Cost Explorer"

https://issues.redhat.com/browse/COST-1105