### PR TITLE
add more identifiers for product and info

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ If you have a first-level application, this field indicates which group should b
 ##### app_id.frontend.module.manifest
 
 If your application shares same manifest as other app or your manifest is located on completely different path, you can pass the path to it in this option.
+
 #### app_id.frontend.paths
 
 This is the list of URL paths where your app will be located.
@@ -144,6 +145,14 @@ This property is used if the app isn't a real app on disk, and only exists for n
 ### Other Optional Properties
 
 The following properties aren't required for all apps, but may still apply to your app:
+
+#### app_id.productId
+
+The Red Hat product ID for your application. This is tied to fields on Portal Case Management for pre-filling information.
+
+#### app_id.infoId
+
+Some applications are mounted in two locations, but use the same base repo (ex. RBAC and MUA), in this case MUA needs to point to RBAC's app.info.json, so this is the base app for that url.
 
 #### app_id.channel
 

--- a/main.yml
+++ b/main.yml
@@ -22,6 +22,7 @@ advisor:
     apiName: insights
   channel: '#advisor'
   deployment_repo: https://github.com/RedHatInsights/insights-advisor-frontend-build
+  productId: Red Hat Insights
   frontend:
     module: advisor#./RootApp
     section: operations
@@ -107,6 +108,7 @@ automation-analytics:
       - v1
     isBeta: true
   deployment_repo: https://github.com/RedHatInsights/tower-analytics-frontend-build.git
+  productId: Ansible Automation Analytics
   frontend:
     section: insights
     paths:
@@ -132,6 +134,7 @@ automation-hub:
     versions:
       - v3
   deployment_repo: https://github.com/RedHatInsights/ansible-hub-ui-build
+  productId: Ansible Automation Hub
   frontend:
     paths:
       - /ansible/automation-hub
@@ -257,6 +260,7 @@ cost-management:
     isBeta: true
   channel: '#koku'
   deployment_repo: https://github.com/RedHatInsights/cost-management-build
+  productId: Red Hat Cost Management
   description: >
     Cost Management is an application that provides users a view of their
     enterprise cost. Cost Management allows users to evaluate the cost on
@@ -531,6 +535,7 @@ migration-analytics:
       - value: "experimental"
         title: "Experimental API"
   deployment_repo: https://github.com/RedHatInsights/xavier-ui-deploy
+  productId: Red Hat Migration Analytics
   frontend:
     paths:
       - /migrations
@@ -547,6 +552,7 @@ mosaic:
 my-user-access:
   title: My User Access
   channel: '#platform-experience'
+  infoId: rbac
   frontend:
     module:
       appName: my-user-access
@@ -582,6 +588,7 @@ openshift:
     versions:
       - v1
   deployment_repo: https://github.com/RedHatInsights/uhc-portal-frontend-deploy.git
+  productId: Red Hat Openshift Cluster Manager
   frontend:
     title: OpenShift Cluster Manager
     paths:
@@ -904,6 +911,7 @@ subscriptions:
       - rhsm-subscriptions
   channel: '#subscriptions'
   deployment_repo: https://github.com/RedHatInsights/curiosity-frontend-build
+  productId: Subscription Watch
   top_level: true
   frontend:
     paths:

--- a/validate-yaml.js
+++ b/validate-yaml.js
@@ -71,7 +71,9 @@ const schema = Joi.object({
     source_repo: Joi.string(),
     frontend: frontendSchema,
     top_level: Joi.boolean(),
-    permissions: [Joi.array().items(permissionsSchema), permissionsSchema]
+    permissions: [Joi.array().items(permissionsSchema), permissionsSchema],
+    productId: Joi.string(),
+    infoId: Joi.string()
 })
 
 const inputfile = 'main.yml';


### PR DESCRIPTION
Creating cases require a product field. Instead of having to figure that out in chrome, just move it here so we can update it.

RBAC and MUA share the same base repository, so we can't find the app.info.json based on the MUA id