### PR TITLE
Flatten Cost Management nav (prod-beta)

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -224,8 +224,38 @@ cost-management:
             args:
               - url: '/api/cost-management/v1/user-access/?type=OCP'
                 accessor: 'data'
-      - id: infrastructure
+      - id: aws
+        title: Amazon Web Services
         group: cost-management
+        permissions:
+          - method: apiRequest
+            args:
+              - url: '/api/cost-management/v1/user-access/?type=AWS'
+                accessor: 'data'
+      - id: azure
+        title: Microsoft Azure
+        group: cost-management
+        permissions:
+          - method: apiRequest
+            args:
+              - url: '/api/cost-management/v1/user-access/?type=AZURE'
+                accessor: 'data'
+      - id: gcp
+        title: Google Cloud Platform
+        group: cost-management
+        permissions:
+          - method: apiRequest
+            args:
+              - url: '/api/cost-management/v1/user-access/?type=GCP&beta=true'
+                accessor: 'data'
+      - id: ibm
+        title: IBM Cloud
+        group: cost-management
+        permissions:
+          - method: apiRequest
+            args:
+              - url: '/api/cost-management/v1/user-access/?type=IBM&beta=true'
+                accessor: 'data'
       - id: cost-models
         title: Cost Models
         group: cost-management
@@ -242,7 +272,7 @@ cost-management:
             args:
               - url: '/api/cost-management/v1/user-access/?type=any&beta=true'
                 accessor: 'data'
-  source_repo: https://github.com/project-koku/
+  source_repo: https://github.com/project-koku-ui/
   mailing_list: cost-mgmt@redhat.com
 
 policies:
@@ -348,40 +378,6 @@ image-builder:
     paths:
       - /insights/image-builder
   source_repo: https://github.com/osbuild/image-builder-frontend
-
-infrastructure:
-  title: Infrastructure
-  frontend:
-    sub_apps:
-      - id: aws
-        title: Amazon Web Services
-        default: true
-        permissions:
-          - method: apiRequest
-            args:
-              - url: '/api/cost-management/v1/user-access/?type=AWS'
-                accessor: 'data'
-      - id: azure
-        title: Microsoft Azure
-        permissions:
-          - method: apiRequest
-            args:
-              - url: '/api/cost-management/v1/user-access/?type=AZURE'
-                accessor: 'data'
-      - id: gcp
-        title: Google Cloud Platform
-        permissions:
-          - method: apiRequest
-            args:
-              - url: '/api/cost-management/v1/user-access/?type=GCP&beta=true'
-                accessor: 'data'
-      - id: ibm
-        title: IBM Cloud
-        permissions:
-          - method: apiRequest
-            args:
-              - url: '/api/cost-management/v1/user-access/?type=IBM&beta=true'
-                accessor: 'data'
 
 ingress:
   title: Ingress


### PR DESCRIPTION
As an in-between step to moving Cost Management under OpenShift, the links shown in the Insights navigation pane must be flattened, first.

This ensures the Insights nav matches the UI's updated routing paths.

https://issues.redhat.com/browse/COST-1145

<img width="1742" alt="Screen Shot 2021-03-12 at 10 47 16 PM" src="https://user-images.githubusercontent.com/17481322/111018077-ecff2d00-8384-11eb-9235-43cd31e40dae.png">