### PR TITLE
Enable subscriptions on openshift

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -945,6 +945,7 @@ subscriptions:
   frontend:
     paths:
       - /insights/subscriptions
+      - /openshift/subscriptions
     sub_apps:
       - id: rhel
         title: All


### PR DESCRIPTION
### Subscription in openshift nav

Since we want to have subscriptions in openshift navigation we should allow users navigating directly to `/openshift/subscriptions` URL and load subs application which will deal with the navigation.