### PR TITLE
Remove custom cost management config and use the main one

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -279,7 +279,7 @@ cost-management:
   docs: https://koku.readthedocs.io/en/latest/
   frontend:
     paths:
-      - /cost-management
+      - /openshift/cost-management
     module:
       appName: cost-management
       group: cost-management
@@ -612,61 +612,6 @@ openshift:
               title: Documentation
               navigate: https://access.redhat.com/documentation/en-us/cost_management_service/
       - id: cost-management
-        title: Cost Management
-        section: insights
-        sub_apps:
-          - id: ''
-            title: Overview
-            group: cost-management
-            reload: ../cost-management
-          - id: ocp
-            title: OpenShift
-            group: cost-management
-            reload: ../cost-management/ocp
-            permissions:
-              - method: apiRequest
-                args:
-                  - url: '/api/cost-management/v1/user-access/?type=OCP'
-                    accessor: 'data'
-          - id: aws
-            title: Amazon Web Services
-            reload: ../cost-management/aws
-            permissions:
-              - method: apiRequest
-                args:
-                  - url: '/api/cost-management/v1/user-access/?type=AWS'
-                    accessor: 'data'
-          - id: azure
-            title: Microsoft Azure
-            reload: ../cost-management/azure
-            permissions:
-              - method: apiRequest
-                args:
-                  - url: '/api/cost-management/v1/user-access/?type=AZURE'
-                    accessor: 'data'
-          - id: gcp
-            title: Google Cloud Platform
-            permissions:
-              - method: apiRequest
-                args:
-                  - url: '/api/cost-management/v1/user-access/?type=GCP&beta=true'
-                    accessor: 'data'
-          - id: cost-models
-            title: Cost models
-            group: cost-management
-            reload: ../cost-management/cost-models
-            permissions:
-              - method: apiRequest
-                args:
-                  - url: '/api/cost-management/v1/user-access/?type=cost_model'
-                    accessor: 'data'
-          - id: cost-explorer
-            title: Cost Explorer
-            group: cost-management
-            reload: /cost-management/explorer
-          - id: cost-management-docs
-            title: Cost Management Documentation
-            navigate: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/#category-cost-management
 
   top_level: true
 


### PR DESCRIPTION
### Make the cost management as subnav of openshift

Since we are changing the navigation of cost-management to be part of Openshift we have to make it as second level nav. Also this will remove the custom cost management page, so cost will be accessible only trough `openshift/cost-management` @dlabrecq is that OK, do you need any help adjusting the navigation in cost app?