### PR TITLE
NOTIF-148 Adds notification/insight submenu in user-preferences

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -567,6 +567,13 @@ my-user-access:
       - /settings
       - /settings/my-user-access
 
+notification:
+  title: Notifications
+  frontend:
+    sub_apps:
+      - id: insights
+        title: Insights
+
 notifications:
   title: Notifications
   api:
@@ -974,6 +981,7 @@ user-preferences:
       - id: email
         title: Email Preferences
         default: true
+      - id: notification
   source_repo: https://github.com/RedHatInsights/user-preferences-frontend
 
 vulnerability:


### PR DESCRIPTION
![Screenshot_2021-03-25_15-45-19](https://user-images.githubusercontent.com/3845764/112549319-3d15c080-8d83-11eb-9f22-70484a2d475a.png)

Adding a Notifications -> Insights menu under UserPreferences. It should link to: `notification/insights`