### PR TITLE
Remove beta flag for GCP (ci-stable)

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -257,7 +257,7 @@ cost-management:
         permissions:
           - method: apiRequest
             args:
-              - url: '/api/cost-management/v1/user-access/?type=GCP&beta=true'
+              - url: '/api/cost-management/v1/user-access/?type=GCP'
                 accessor: 'data'
       - id: ibm
         title: IBM Cloud


### PR DESCRIPTION
The Cost Management team is ready to enable the GCP feature in production. To do that, we need to remove the beta=true flag from our user-access API request. The flag hides the feature from our stage and production environments.

https://issues.redhat.com/browse/COST-1225