### PR TITLE
Adjusting placement of Manifests on submenu per April…

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -935,10 +935,11 @@ subscriptions:
       - id: openshift-subscription
         title: OpenShift Subscriptions
         reload: '../openshift/subscriptions/openshift-container'
+      - id: subscription-central
       - id: subscriptions-documentation
         title: Subscriptions Documentation
         navigate: https://access.redhat.com/products/subscription-central?extIdCarryOver=true&sc_cid=701f2000001Css5AAC
-      - id: subscription-central
+      
 
 
   source_repo: https://github.com/RedHatInsights/curiosity-frontend


### PR DESCRIPTION
… Summit URL Change Details

Internal doc shows this Manifests link should be placed above Documentation, under Subscriptions.  