### PR TITLE
TEAMNADO-2098 Renaming Subscription Central App to Manifests

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -519,6 +519,20 @@ landing:
   deployment_repo: https://github.com/RedHatInsights/landing-page-frontend-build
   source_repo: https://github.com/RedHatInsights/landing-page-frontend
 
+manifests:
+  title: Manifests
+  channel: '#subscription-central'
+  deployment_repo: https://github.com/RedHatInsights/subscription-central-ui-build
+  frontend:
+    module:
+      appName: manifests
+      scope: manifests
+      module: ./RootApp
+    paths:
+      - /insights/subscriptions/manifests
+    reload: subscriptions/manifests
+  source_repo: https://github.com/RedHatInsights/subscription-central-ui
+  
 migrations:
   title: Migrations
   frontend:
@@ -900,20 +914,6 @@ storybook:
       - /docs/storybook
   source_repo: https://github.com/RedHatInsights/insights-frontend-storybook
 
-subscription-central:
-  title: Manifests
-  channel: '#subscription-central'
-  deployment_repo: https://github.com/RedHatInsights/subscription-central-ui-build
-  frontend:
-    module:
-      appName: subscription-central
-      scope: subscriptionCentral
-      module: ./RootApp
-    paths:
-      - /insights/subscriptions/manifests
-    reload: subscriptions/manifests
-  source_repo: https://github.com/RedHatInsights/subscription-central-ui
-
 subscriptions:
   title: Subscription Watch
   api:
@@ -944,7 +944,7 @@ subscriptions:
       - id: openshift-subscription
         title: OpenShift Subscriptions
         reload: '../openshift/subscriptions/openshift-container'
-      - id: subscription-central
+      - id: manifests
       - id: subscriptions-documentation
         title: Subscriptions Documentation
         navigate: https://access.redhat.com/products/subscription-central?extIdCarryOver=true&sc_cid=701f2000001Css5AAC


### PR DESCRIPTION
cc @karelhala @Hyperkid123 

After confirmation with management, we are changing the name of this app within config from `subscription-central` to `manifests` so that default side navigation behavior works correctly.

### Changes
- Renamed `subscription-central` app to be `manifests`
- moved config up to be consistent with alphabetical order
- updated the sub-app within `subscriptions` to `manifests`
