### PR TITLE
dynamically show image-builder in nav

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -436,6 +436,11 @@ frontend-assets:
 image-builder:
   title: Image Builder
   deployment_repo: https://github.com/RedHatInsights/image-builder-frontend-build
+  permissions:
+    method: apiRequest
+    args:
+      - url: '/api/image-builder/v1/version'
+        matcher: isNotEmpty
   frontend:
     section: operations
     paths:


### PR DESCRIPTION
This shows image-builder if and only if the user's org is in the allow
list for the private beta.

In stage, everyone is currently signed up, so this should be a noop.
Once verified, the same logic should be applied in prod, potentially
fixing https://issues.redhat.com/browse/RHCLOUD-13332.

Ref: https://github.com/RedHatInsights/insights-chrome/blob/master/docs/navigation.md

Suggested by @ryelo.