### PR TITLE
dynamically show image-builder in nav

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -397,6 +397,11 @@ frontend-assets:
 image-builder:
   title: Image Builder
   deployment_repo: https://github.com/RedHatInsights/image-builder-frontend-build
+  permissions:
+    method: apiRequest
+    args:
+      - url: '/api/image-builder/v1/version'
+        matcher: isNotEmpty
   frontend:
     paths:
       - /insights/image-builder
@@ -421,6 +426,7 @@ insights:
       - id: patch
       - id: drift
       - id: policies
+      - id: image-builder
       - id: inventory
       - id: remediations
       - id: registration


### PR DESCRIPTION
This shows image-builder if and only if the user's org is in the
allow list for the private beta.

The way image-builder has shown up in beta has changed a few times
over the past few months, so to avoid any confusion, I'll
summarize the history:
 - image-builder was first shown unconditionally in the navbar
   and for users who were not signed up the frontend would show
   but be non-functional
 - image-builder was removed from the navbar as the non-funcitonal
   UI was not great, users could still access the UI by going
   directly to the URL
 - the UI was replaced with a "request access" screen for users
   who were not signed up, if they were to access the URL
 - a change to the chrome meant that the image-builder UI stopped
   working at all for all users, due to it not being in the nav

With this patch, signed-up users will see image-builder in the nav
and it will be fully functional, users who are not signed-up will
not see image-builder in the nav, and cannot use the UI as before.

This should fix https://issues.redhat.com/browse/RHCLOUD-13332.

This reverts commit 0ab4d67f8cab1d127606a9f2d57830c992f3ee80.