### PR TITLE
Promote redirects to prod-beta

### DIFF
--- a/akamai/data/prod/base_rules.json
+++ b/akamai/data/prod/base_rules.json
@@ -301,7 +301,7 @@
                         "name": "Redirects",
                         "children": [
                             {
-                                "name": "Beta RHEL",
+                                "name": "Beta OpenShift Insights Subscriptions RHEL",
                                 "children": [],
                                 "behaviors": [
                                     {
@@ -313,7 +313,7 @@
                                             "destinationPath": "OTHER",
                                             "queryString": "APPEND",
                                             "responseCode": 301,
-                                            "destinationPathOther": "/beta/insights"
+                                            "destinationPathOther": "/beta/insights/subscriptions/rhel"
                                         }
                                     }
                                 ],
@@ -323,7 +323,7 @@
                                         "options": {
                                             "matchOperator": "MATCHES_ONE_OF",
                                             "values": [
-                                                "/beta/rhel"
+                                                "/beta/subscriptions/rhel-sw/all*"
                                             ],
                                             "matchCaseSensitive": false,
                                             "normalize": false
@@ -333,7 +333,7 @@
                                 "criteriaMustSatisfy": "all"
                             },
                             {
-                                "name": "Beta RHEL Dashboard",
+                                "name": "Beta OpenShift Insights Cost-Management Overview",
                                 "children": [],
                                 "behaviors": [
                                     {
@@ -345,7 +345,7 @@
                                             "destinationPath": "OTHER",
                                             "queryString": "APPEND",
                                             "responseCode": 301,
-                                            "destinationPathOther": "/beta/insights/dashboard"
+                                            "destinationPathOther": "/beta/openshift/cost-management"
                                         }
                                     }
                                 ],
@@ -355,7 +355,7 @@
                                         "options": {
                                             "matchOperator": "MATCHES_ONE_OF",
                                             "values": [
-                                                "/beta/rhel/dashboard*"
+                                                "/beta/cost-management*"
                                             ],
                                             "matchCaseSensitive": false,
                                             "normalize": false
@@ -365,7 +365,7 @@
                                 "criteriaMustSatisfy": "all"
                             },
                             {
-                                "name": "Beta RHEL Vulnerability",
+                                "name": "Beta OpenShift Insights Cost-Management OpenShfit",
                                 "children": [],
                                 "behaviors": [
                                     {
@@ -377,7 +377,7 @@
                                             "destinationPath": "OTHER",
                                             "queryString": "APPEND",
                                             "responseCode": 301,
-                                            "destinationPathOther": "/beta/insights/vulnerability"
+                                            "destinationPathOther": "/beta/openshift/cost-management/ocp"
                                         }
                                     }
                                 ],
@@ -387,7 +387,7 @@
                                         "options": {
                                             "matchOperator": "MATCHES_ONE_OF",
                                             "values": [
-                                                "/beta/rhel/vulnerability*"
+                                                "/beta/cost-management/ocp*"
                                             ],
                                             "matchCaseSensitive": false,
                                             "normalize": false
@@ -397,7 +397,7 @@
                                 "criteriaMustSatisfy": "all"
                             },
                             {
-                                "name": "Beta RHEL Compliance",
+                                "name": "Beta OpenShift Insights Cost-Management AWS",
                                 "children": [],
                                 "behaviors": [
                                     {
@@ -409,7 +409,7 @@
                                             "destinationPath": "OTHER",
                                             "queryString": "APPEND",
                                             "responseCode": 301,
-                                            "destinationPathOther": "/beta/insights/compliance"
+                                            "destinationPathOther": "/beta/openshift/cost-management/aws"
                                         }
                                     }
                                 ],
@@ -419,7 +419,7 @@
                                         "options": {
                                             "matchOperator": "MATCHES_ONE_OF",
                                             "values": [
-                                                "/beta/rhel/compliance*"
+                                                "/beta/cost-management/infrastructure/aws*"
                                             ],
                                             "matchCaseSensitive": false,
                                             "normalize": false
@@ -429,7 +429,7 @@
                                 "criteriaMustSatisfy": "all"
                             },
                             {
-                                "name": "Beta RHEL Drift",
+                                "name": "Beta OpenShift Insights Cost-Management Azure",
                                 "children": [],
                                 "behaviors": [
                                     {
@@ -441,7 +441,7 @@
                                             "destinationPath": "OTHER",
                                             "queryString": "APPEND",
                                             "responseCode": 301,
-                                            "destinationPathOther": "/beta/insights/drift"
+                                            "destinationPathOther": "/beta/openshift/cost-management/azure"
                                         }
                                     }
                                 ],
@@ -451,7 +451,7 @@
                                         "options": {
                                             "matchOperator": "MATCHES_ONE_OF",
                                             "values": [
-                                                "/beta/rhel/drift*"
+                                                "/beta/cost-management/infrastructure/azure*"
                                             ],
                                             "matchCaseSensitive": false,
                                             "normalize": false
@@ -461,7 +461,7 @@
                                 "criteriaMustSatisfy": "all"
                             },
                             {
-                                "name": "Beta RHEL Remediations",
+                                "name": "Beta OpenShift Insights Cost-Management Google Cloud",
                                 "children": [],
                                 "behaviors": [
                                     {
@@ -473,7 +473,7 @@
                                             "destinationPath": "OTHER",
                                             "queryString": "APPEND",
                                             "responseCode": 301,
-                                            "destinationPathOther": "/beta/insights/remediations"
+                                            "destinationPathOther": "/beta/openshift/cost-management/gcp"
                                         }
                                     }
                                 ],
@@ -483,7 +483,7 @@
                                         "options": {
                                             "matchOperator": "MATCHES_ONE_OF",
                                             "values": [
-                                                "/beta/rhel/remediations*"
+                                                "/beta/cost-management/infrastructure/gcp*"
                                             ],
                                             "matchCaseSensitive": false,
                                             "normalize": false
@@ -493,7 +493,7 @@
                                 "criteriaMustSatisfy": "all"
                             },
                             {
-                                "name": "Beta RHEL Inventory",
+                                "name": "Beta OpenShift Insights Cost-management Cost Models",
                                 "children": [],
                                 "behaviors": [
                                     {
@@ -505,7 +505,7 @@
                                             "destinationPath": "OTHER",
                                             "queryString": "APPEND",
                                             "responseCode": 301,
-                                            "destinationPathOther": "/beta/insights/inventory"
+                                            "destinationPathOther": "/beta/openshift/cost-management/cost-models"
                                         }
                                     }
                                 ],
@@ -515,7 +515,7 @@
                                         "options": {
                                             "matchOperator": "MATCHES_ONE_OF",
                                             "values": [
-                                                "/beta/rhel/inventory*"
+                                                "/beta/cost-management/cost-models*"
                                             ],
                                             "matchCaseSensitive": false,
                                             "normalize": false
@@ -525,7 +525,7 @@
                                 "criteriaMustSatisfy": "all"
                             },
                             {
-                                "name": "Beta Insights Rules",
+                                "name": "Beta RHEL Business Insights Subscriptions ARM",
                                 "children": [],
                                 "behaviors": [
                                     {
@@ -537,7 +537,7 @@
                                             "destinationPath": "OTHER",
                                             "queryString": "APPEND",
                                             "responseCode": 301,
-                                            "destinationPathOther": "/beta/insights/advisor/recommendations"
+                                            "destinationPathOther": "/beta/insights/subscriptions/rhel-arm"
                                         }
                                     }
                                 ],
@@ -547,7 +547,7 @@
                                         "options": {
                                             "matchOperator": "MATCHES_ONE_OF",
                                             "values": [
-                                                "/beta/insights/rules*"
+                                                "/beta/subscriptions/rhel-sw/arm*"
                                             ],
                                             "matchCaseSensitive": false,
                                             "normalize": false
@@ -557,7 +557,7 @@
                                 "criteriaMustSatisfy": "all"
                             },
                             {
-                                "name": "Beta Insights Topics",
+                                "name": "Beta RHEL Business Insights Subscriptions IBM Power",
                                 "children": [],
                                 "behaviors": [
                                     {
@@ -569,7 +569,7 @@
                                             "destinationPath": "OTHER",
                                             "queryString": "APPEND",
                                             "responseCode": 301,
-                                            "destinationPathOther": "/beta/insights/advisor/topics"
+                                            "destinationPathOther": "/beta/insights/subscriptions/rhel-ibmpower"
                                         }
                                     }
                                 ],
@@ -579,7 +579,295 @@
                                         "options": {
                                             "matchOperator": "MATCHES_ONE_OF",
                                             "values": [
-                                                "/beta/insights/topics*"
+                                                "/beta/subscriptions/rhel-sw/ibmpower*"
+                                            ],
+                                            "matchCaseSensitive": false,
+                                            "normalize": false
+                                        }
+                                    }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            {
+                                "name": "Beta RHEL Business Insights IBM Z Systems",
+                                "children": [],
+                                "behaviors": [
+                                    {
+                                        "name": "redirect",
+                                        "options": {
+                                            "mobileDefaultChoice": "DEFAULT",
+                                            "destinationProtocol": "SAME_AS_REQUEST",
+                                            "destinationHostname": "SAME_AS_REQUEST",
+                                            "destinationPath": "OTHER",
+                                            "queryString": "APPEND",
+                                            "responseCode": 301,
+                                            "destinationPathOther": "/beta/insights/subscriptions/rhel-ibmz"
+                                        }
+                                    }
+                                ],
+                                "criteria": [
+                                    {
+                                        "name": "path",
+                                        "options": {
+                                            "matchOperator": "MATCHES_ONE_OF",
+                                            "values": [
+                                                "/beta/subscriptions/rhel-sw/ibmz*"
+                                            ],
+                                            "matchCaseSensitive": false,
+                                            "normalize": false
+                                        }
+                                    }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            {
+                                "name": "Beta RHEL Business Insights Subscriptions X86",
+                                "children": [],
+                                "behaviors": [
+                                    {
+                                        "name": "redirect",
+                                        "options": {
+                                            "mobileDefaultChoice": "DEFAULT",
+                                            "destinationProtocol": "SAME_AS_REQUEST",
+                                            "destinationHostname": "SAME_AS_REQUEST",
+                                            "destinationPath": "OTHER",
+                                            "queryString": "APPEND",
+                                            "responseCode": 301,
+                                            "destinationPathOther": "/beta/insights/subscriptions/rhel-x86"
+                                        }
+                                    }
+                                ],
+                                "criteria": [
+                                    {
+                                        "name": "path",
+                                        "options": {
+                                            "matchOperator": "MATCHES_ONE_OF",
+                                            "values": [
+                                                "/beta/subscriptions/rhel-sw/x86*"
+                                            ],
+                                            "matchCaseSensitive": false,
+                                            "normalize": false
+                                        }
+                                    }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            {
+                                "name": "Beta RHEL Business Insights Resource Optimization",
+                                "children": [],
+                                "behaviors": [
+                                    {
+                                        "name": "redirect",
+                                        "options": {
+                                            "mobileDefaultChoice": "DEFAULT",
+                                            "destinationProtocol": "SAME_AS_REQUEST",
+                                            "destinationHostname": "SAME_AS_REQUEST",
+                                            "destinationPath": "OTHER",
+                                            "queryString": "APPEND",
+                                            "responseCode": 301,
+                                            "destinationPathOther": "/beta/rhel/ros"
+                                        }
+                                    }
+                                ],
+                                "criteria": [
+                                    {
+                                        "name": "path",
+                                        "options": {
+                                            "matchOperator": "MATCHES_ONE_OF",
+                                            "values": [
+                                                "/beta/insights/ros*"
+                                            ],
+                                            "matchCaseSensitive": false,
+                                            "normalize": false
+                                        }
+                                    }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            {
+                                "name": "Beta Ansible Automation Insights",
+                                "children": [],
+                                "behaviors": [
+                                    {
+                                        "name": "redirect",
+                                        "options": {
+                                            "mobileDefaultChoice": "DEFAULT",
+                                            "destinationProtocol": "SAME_AS_REQUEST",
+                                            "destinationHostname": "SAME_AS_REQUEST",
+                                            "destinationPath": "OTHER",
+                                            "queryString": "APPEND",
+                                            "responseCode": 301,
+                                            "destinationPathOther": "/beta/ansible/insights"
+                                        }
+                                    }
+                                ],
+                                "criteria": [
+                                    {
+                                        "name": "path",
+                                        "options": {
+                                            "matchOperator": "MATCHES_ONE_OF",
+                                            "values": [
+                                                "/beta/ansible/automation-analytics*"
+                                            ],
+                                            "matchCaseSensitive": false,
+                                            "normalize": false
+                                        }
+                                    }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            {
+                                "name": "Beta Ansible Automation Insights Automation Calculator",
+                                "children": [],
+                                "behaviors": [
+                                    {
+                                        "name": "redirect",
+                                        "options": {
+                                            "mobileDefaultChoice": "DEFAULT",
+                                            "destinationProtocol": "SAME_AS_REQUEST",
+                                            "destinationHostname": "SAME_AS_REQUEST",
+                                            "destinationPath": "OTHER",
+                                            "queryString": "APPEND",
+                                            "responseCode": 301,
+                                            "destinationPathOther": "/beta/ansible/insights/automation-calculator"
+                                        }
+                                    }
+                                ],
+                                "criteria": [
+                                    {
+                                        "name": "path",
+                                        "options": {
+                                            "matchOperator": "MATCHES_ONE_OF",
+                                            "values": [
+                                                "/beta/ansible/automation-analytics/automation-calculator*"
+                                            ],
+                                            "matchCaseSensitive": false,
+                                            "normalize": false
+                                        }
+                                    }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            {
+                                "name": "Beta Ansible Automation Insights Organization Statistics",
+                                "children": [],
+                                "behaviors": [
+                                    {
+                                        "name": "redirect",
+                                        "options": {
+                                            "mobileDefaultChoice": "DEFAULT",
+                                            "destinationProtocol": "SAME_AS_REQUEST",
+                                            "destinationHostname": "SAME_AS_REQUEST",
+                                            "destinationPath": "OTHER",
+                                            "queryString": "APPEND",
+                                            "responseCode": 301,
+                                            "destinationPathOther": "/beta/ansible/insights/organization-statistics"
+                                        }
+                                    }
+                                ],
+                                "criteria": [
+                                    {
+                                        "name": "path",
+                                        "options": {
+                                            "matchOperator": "MATCHES_ONE_OF",
+                                            "values": [
+                                                "/beta/ansible/automation-analytics/organization-statistics*"
+                                            ],
+                                            "matchCaseSensitive": false,
+                                            "normalize": false
+                                        }
+                                    }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            {
+                                "name": "Beta Ansible Automation Insights Job Explorer",
+                                "children": [],
+                                "behaviors": [
+                                    {
+                                        "name": "redirect",
+                                        "options": {
+                                            "mobileDefaultChoice": "DEFAULT",
+                                            "destinationProtocol": "SAME_AS_REQUEST",
+                                            "destinationHostname": "SAME_AS_REQUEST",
+                                            "destinationPath": "OTHER",
+                                            "queryString": "APPEND",
+                                            "responseCode": 301,
+                                            "destinationPathOther": "/beta/ansible/insights/job-explorer"
+                                        }
+                                    }
+                                ],
+                                "criteria": [
+                                    {
+                                        "name": "path",
+                                        "options": {
+                                            "matchOperator": "MATCHES_ONE_OF",
+                                            "values": [
+                                                "/beta/ansible/automation-analytics/job-explorer*"
+                                            ],
+                                            "matchCaseSensitive": false,
+                                            "normalize": false
+                                        }
+                                    }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            {
+                                "name": "Beta Ansible Automation Insights Cluster",
+                                "children": [],
+                                "behaviors": [
+                                    {
+                                        "name": "redirect",
+                                        "options": {
+                                            "mobileDefaultChoice": "DEFAULT",
+                                            "destinationProtocol": "SAME_AS_REQUEST",
+                                            "destinationHostname": "SAME_AS_REQUEST",
+                                            "destinationPath": "OTHER",
+                                            "queryString": "APPEND",
+                                            "responseCode": 301,
+                                            "destinationPathOther": "/beta/ansible/insights/clusters"
+                                        }
+                                    }
+                                ],
+                                "criteria": [
+                                    {
+                                        "name": "path",
+                                        "options": {
+                                            "matchOperator": "MATCHES_ONE_OF",
+                                            "values": [
+                                                "/beta/ansible/automation-analytics/clusters*"
+                                            ],
+                                            "matchCaseSensitive": false,
+                                            "normalize": false
+                                        }
+                                    }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            {
+                                "name": "Beta Ansible Automation Insights Notifications",
+                                "children": [],
+                                "behaviors": [
+                                    {
+                                        "name": "redirect",
+                                        "options": {
+                                            "mobileDefaultChoice": "DEFAULT",
+                                            "destinationProtocol": "SAME_AS_REQUEST",
+                                            "destinationHostname": "SAME_AS_REQUEST",
+                                            "destinationPath": "OTHER",
+                                            "queryString": "APPEND",
+                                            "responseCode": 301,
+                                            "destinationPathOther": "/beta/ansible/insights/notifications"
+                                        }
+                                    }
+                                ],
+                                "criteria": [
+                                    {
+                                        "name": "path",
+                                        "options": {
+                                            "matchOperator": "MATCHES_ONE_OF",
+                                            "values": [
+                                                "/beta/ansible/automation-analytics/notifications*"
                                             ],
                                             "matchCaseSensitive": false,
                                             "normalize": false


### PR DESCRIPTION
Basically copy pasted from the stage-beta
Depend on this to be deployed and verified: https://github.com/RedHatInsights/cloud-services-config/pull/504

1. Remove redirects from /rhel to /insights
2. Add redirects for new urls

JIRA: https://issues.redhat.com/browse/RHCLOUD-13060

Doc is here, RHEL Nav section:
https://docs.google.com/document/d/1NkAwv1JT22-iG-erPLMToJ3WGxadjVV8SVg-2j8WxCI/edit#heading=h.24lar9o0onc

