### PR TITLE
Remove notifications from nav on production

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -572,9 +572,6 @@ notifications:
         title: Red Hat Enterprise Linux
         group: notifications
         default: true
-      - id: openshift
-        title: OpenShift
-        group: notifications
   source_repo: https://github.com/RedHatInsights/notifications-frontend
 
 openshift:
@@ -959,16 +956,6 @@ user-preferences:
         title: Email Preferences
         default: true
         group: email
-      - id: notifications
-        title: Notifications
-        group: email
-        sub_apps:
-            - id: rhel
-              title: Red Hat Enterprise Linux
-              group: email
-            - id: openshift
-              title: Openshift
-              group: email
   source_repo: https://github.com/RedHatInsights/user-preferences-frontend
 
 vulnerability:


### PR DESCRIPTION
### Remove notifications

Notifications team doesn't want to have their navigation on prod-beta as their applications are not ready yet.