### PR TITLE
Add Releases page to OpenShift Cluster Manager

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -578,6 +578,9 @@ openshift:
       - id: overview
         title: Overview
         group: openshift
+      - id: releases
+        title: Releases
+        group: openshift
       - id: subscriptions
         title: Subscriptions
         section: insights
@@ -884,7 +887,7 @@ subscriptions:
       - id: subscriptions-documentation
         title: Subscriptions Documentation
         navigate: https://access.redhat.com/products/subscription-central?extIdCarryOver=true&sc_cid=701f2000001Css5AAC
-      
+
 
 
   source_repo: https://github.com/RedHatInsights/curiosity-frontend


### PR DESCRIPTION
The page was released to production yesterday, so this change can go to `prod-beta` now.  But this change and the other recent OCM nav changes won't go to `prod-stable` until next week.