### PR TITLE
Add Releases page to OpenShift Cluster Manager

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -543,6 +543,9 @@ openshift:
       - id: overview
         title: Overview
         group: openshift
+      - id: releases
+        title: Releases
+        group: openshift
       - id: subscriptions
         title: Subscriptions
         section: insights


### PR DESCRIPTION
I was out on PTO last week and didn't get this change in with the the release of the `Releases` page in OpenShift Cluster Manager, so adding it now.