### PR TITLE
chore: add sr-ui

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -669,6 +669,9 @@ application-services:
       - id: cos
         title: "Connectors"
         group: overview
+      - id: sr
+        title: "Service Registry"
+        group: overview
   top_level: true
   source_repo: https://github.com/bf2fc6cc711aee1a0c2a/mk-ui-host
 
@@ -686,6 +689,10 @@ rhosak-control-plane-ui-build:
 cos-ui-build:
   title: UI for COS
   deployment_repo: https://github.com/RedHatInsights/cos-ui-build
+
+sr-ui-build:
+  title: UI for Service Registry
+  deployment_repo: https://github.com/RedHatInsights/sr-ui-build
 
 rhoas-guides-build:
   title: Guides for RHOAS


### PR DESCRIPTION
This is a twin PR of this one https://github.com/RedHatInsights/cloud-services-config/pull/612

We will deploy Service Registry, and we will need the creation of a corresponding repo.
Service Registry UI will be included as a federated module, just like Connectors and kas