### PR TITLE
image-builder: Migrate to chrome 2.0

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -395,6 +395,10 @@ frontend-assets:
 
 image-builder:
   title: Image Builder
+  api:
+    versions:
+      - v1
+    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/image-builder-frontend-build
   permissions:
     method: apiRequest
@@ -403,6 +407,11 @@ image-builder:
         matcher: isNotEmpty
   frontend:
     section: operations
+    module:
+      appName: image-builder
+      scope: image_builder
+      module: ./RootApp
+    title: Image Builder
     paths:
       - /insights/image-builder
   source_repo: https://github.com/osbuild/image-builder-frontend


### PR DESCRIPTION
This was already deloyed in stage, and it works fine. Doing the same for prod-beta now, as soon as this is in and deployed, I'll release the frontend into prod-beta, and then the migration to 2.0 should be complete.