### PR TITLE
Revert "feat(openshift): add federated module (#633)"

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -494,11 +494,6 @@ openshift:
   deployment_repo: https://github.com/RedHatInsights/uhc-portal-frontend-deploy.git
   productId: Red Hat Openshift Cluster Manager
   frontend:
-    module:
-      appName: openshift
-      scope: openshift
-      module: ./RootApp
-      group: openshift
     title: OpenShift
     paths:
       - /openshift


### PR DESCRIPTION
This reverts commit 6cf5242a9514869c8c66b271fbd01ad110c527a3.

The chrome 2.0 change broke the API tokens page at https://cloud.redhat.com/openshift/token
we have no choice but to go back to the old chrome until this is fixed.

cc: @karelhala @redallen 