### PR TITLE
chore: add srs-ui-build repo for service registry control plane UI

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -708,6 +708,10 @@ sr-ui-build:
   title: UI for Service Registry
   deployment_repo: https://github.com/RedHatInsights/sr-ui-build
 
+srs-ui-build:
+  title: UI for Service Registry Control Plane
+  deployment_repo: https://github.com/RedHatInsights/srs-ui-build
+
 rhoas-guides-build:
   title: Guides for RHOAS
   deployment_repo: https://github.com/RedHatInsights/rhoas-guides-build


### PR DESCRIPTION
New repo for service registry control plane UI.

Please create repo `srs-ui-build` for service registry control plane UI