### PR TITLE
[ci-beta] Remove the isBeta flag for catalog and approval apis

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -107,7 +107,6 @@ approval:
   api:
     versions:
       - v1
-    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/approvals-frontend-deploy.git
   frontend:
     module:
@@ -175,7 +174,6 @@ catalog:
   api:
     versions:
       - v1
-    isBeta: true
   channel: '#insights-catalog'
   deployment_repo: https://github.com/RedHatInsights/catalog-static-deploy
   frontend:


### PR DESCRIPTION
Remove the isBeta flag for catalog and approval apis so they will be displayed in the doc api list