### PR TITLE
[prod-beta] Remove the beta flag for the catalog and approval apis

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -92,7 +92,6 @@ approval:
   api:
     versions:
       - v1
-    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/approvals-frontend-deploy.git
   frontend:
     module:
@@ -160,7 +159,6 @@ catalog:
   api:
     versions:
       - v1
-    isBeta: true
   channel: '#insights-catalog'
   deployment_repo: https://github.com/RedHatInsights/catalog-static-deploy
   frontend:


### PR DESCRIPTION
 Remove the beta flag for the catalog and approval apis so these are displayed in the doc api list for beta and not beta