### PR TITLE
[ci-stable] Remove the beta flag for the catalog and approval apis

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -76,7 +76,6 @@ approval:
   api:
     versions:
       - v1
-    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/approvals-frontend-deploy.git
   frontend:
     module:
@@ -144,7 +143,6 @@ catalog:
   api:
     versions:
       - v1
-    isBeta: true
   channel: '#insights-catalog'
   deployment_repo: https://github.com/RedHatInsights/catalog-static-deploy
   frontend:


### PR DESCRIPTION
Remove the beta flag for the catalog and approval apis for display in the doc api list