### PR TITLE
[qa-stable] Remove the beta flag for the catalog and approval apis

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -116,7 +116,6 @@ approval:
   api:
     versions:
       - v1
-    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/approvals-frontend-deploy.git
   frontend:
     module:
@@ -184,7 +183,6 @@ catalog:
   api:
     versions:
       - v1
-    isBeta: true
   channel: '#insights-catalog'
   deployment_repo: https://github.com/RedHatInsights/catalog-static-deploy
   frontend:


### PR DESCRIPTION
Remove the beta flag for the catalog and approval apis in order to have these displayed in the doc api list