### PR TITLE
[prod-stable] Remove the beta flag for the catalog api

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -168,7 +168,6 @@ catalog:
   api:
     versions:
       - v1
-    isBeta: true
   channel: '#insights-catalog'
   deployment_repo: https://github.com/RedHatInsights/catalog-static-deploy
   frontend:


### PR DESCRIPTION
Remove the beta flag for the catalog api to have the entrypoints displayed in the doc api list