### PR TITLE
Add ansible-dashboard group to ansible-dashboard

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -45,7 +45,7 @@ ansible-dashboard:
       appName: ansible-dashboard
       scope: ansibleDashboard
       module: ./RootApp
-      group: ansible
+      group: ansible-dashboard
     paths:
       - /ansible
       - /ansible/ansible-dashboard
@@ -57,6 +57,7 @@ ansible:
     sub_apps:
       - id: ansible-dashboard
         default: true
+        group: ansible-dashboard
       - id: automation-hub
       - id: catalog
       - id: automation-analytics


### PR DESCRIPTION
There is an error on ci/qa/stage-beta where if user navigates to non-chrome2 app in ansible bundle dashboard is always visible. This PR fixes such issue, by using different group for the ansible-dashboard (other than the section partial) and using this group definition in app definition as well.