### PR TITLE
[qa-stable] Add ansible dashboard

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -21,12 +21,28 @@ advisor:
         title: Topics
   source_repo: https://github.com/RedHatInsights/insights-advisor-frontend
 
+ansible-dashboard:
+  title: Overview
+  deployment_repo: https://github.com/RedHatInsights/ansible-platform-dashboard-build
+  frontend:
+    module:
+      appName: ansible-dashboard
+      scope: ansibleDashboard
+      module: ./RootApp
+      group: ansible-dashboard
+    paths:
+      - /ansible
+      - /ansible/ansible-dashboard
+  source_repo: https://github.com/RedHatInsights/ansible-platform-dashboard
+
 ansible:
   title: Ansible Automation Platform
   frontend:
     sub_apps:
-      - id: automation-hub
+      - id: ansible-dashboard
         default: true
+        group: ansible-dashboard
+      - id: automation-hub
       - id: catalog
       - id: automation-analytics
   top_level: true
@@ -138,8 +154,7 @@ automation-analytics:
   frontend:
     section: insights
     paths:
-      - /ansible
-      - /ansible/automation-analytics
+      - /ansible/insights
     sub_apps:
       - id : automation-calculator
         title: Automation Calculator
@@ -149,7 +164,6 @@ automation-analytics:
         title: Job Explorer
       - id: clusters
         title: Clusters
-        default: true
       - id: notifications
         title: Notifications
   source_repo: https://github.com/RedHatInsights/tower-analytics-frontend


### PR DESCRIPTION
* Add ansible platform landing page

* Remove ansible root path from the ansible-dashboard

* Set the Ansible Dashboard as the default path for the ansible path (#650)

* Add ansible-dashboard group to ansible-dashboard (#659)

Co-authored-by: Karel Hala <khala@redhat.com>