### PR TITLE
Add origin for gov.cloud.stage.redhat.com

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,7 @@ node {
         withCredentials([
           file(credentialsId: "rhcs-akamai-edgerc", variable: 'EDGERC'),
           file(credentialsId: "rhcs-$ENVSTR-3scale-origin-json", variable: 'GATEWAYORIGINJSON'),
+          file(credentialsId: "rhcs-$ENVSTR-gov-3scale-origin-json", variable: 'FEDRAMPORIGINJSON'),
           file(credentialsId: "rhcs-$ENVSTR-turnpike-origin-json", variable: 'TURNPIKEORIGINJSON'),
           file(credentialsId: "rhcs-openshift-origin-json", variable: 'OPENSHIFTORIGINJSON'),
           file(credentialsId: "rhcs-openshift-mirror-origin-json", variable: 'OPENSHIFTORIGINMIRRORJSON'),

--- a/akamai/data/prod/base_rules.json
+++ b/akamai/data/prod/base_rules.json
@@ -1601,6 +1601,57 @@
                             }
                         ],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -1612,7 +1663,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -1652,12 +1702,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {
@@ -2060,6 +2104,57 @@
                         ],
                         "criteria": [],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -2071,7 +2166,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -2111,12 +2205,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {
@@ -2808,37 +2896,6 @@
                     }
                 ],
                 "name": "Client Cert"
-            },
-            {
-                "name": "Redirect Top Level for FedRAMP",
-                "children": [],
-                "behaviors": [
-                    {
-                        "name": "redirect",
-                        "options": {
-                            "queryString": "APPEND",
-                            "responseCode": 301,
-                            "destinationHostname": "OTHER",
-                            "destinationPath": "SAME_AS_REQUEST",
-                            "destinationProtocol": "SAME_AS_REQUEST",
-                            "mobileDefaultChoice": "DEFAULT",
-                            "destinationHostnameOther": "api-gateway-stage.apps.crcgovs02ue1.43j0.p1.openshiftapps.com"
-                        }
-                    }
-                ],
-                "criteria": [
-                    {
-                        "name": "hostname",
-                        "options": {
-                            "matchOperator": "IS_ONE_OF",
-                            "values": [
-                                "gov.cloud.redhat.com"
-                            ]
-                        }
-                    }
-                ],
-                "criteriaMustSatisfy": "all",
-                "comments": ""
             }
         ],
         "options": {

--- a/akamai/data/stage/base_rules.json
+++ b/akamai/data/stage/base_rules.json
@@ -1667,6 +1667,57 @@
                             }
                         ],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -1678,7 +1729,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -1718,12 +1768,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {
@@ -2075,6 +2119,57 @@
                         ],
                         "criteria": [],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -2086,7 +2181,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -2126,12 +2220,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {
@@ -2400,37 +2488,6 @@
                     }
                 ],
                 "name": "Client Cert"
-            },
-            {
-                "name": "Redirect Top Level",
-                "children": [],
-                "behaviors": [
-                    {
-                        "name": "redirect",
-                        "options": {
-                            "queryString": "APPEND",
-                            "responseCode": 301,
-                            "destinationHostname": "OTHER",
-                            "destinationPath": "SAME_AS_REQUEST",
-                            "destinationProtocol": "SAME_AS_REQUEST",
-                            "mobileDefaultChoice": "DEFAULT",
-                            "destinationHostnameOther": "api-gateway-stage.apps.crcgovs02ue1.43j0.p1.openshiftapps.com"
-                        }
-                    }
-                ],
-                "criteria": [
-                    {
-                        "name": "hostname",
-                        "options": {
-                            "matchOperator": "IS_ONE_OF",
-                            "values": [
-                                "gov.cloud.stage.redhat.com"
-                            ]
-                        }
-                    }
-                ],
-                "criteriaMustSatisfy": "all",
-                "comments": ""
             }
         ],
         "options": {

--- a/akamai/update_api.py
+++ b/akamai/update_api.py
@@ -100,6 +100,7 @@ def updatePropertyRulesUsingConfig(version_number, master_config_list, crc_env =
         ("<<certauth-gateway-secret>>", util.getEnvVar("CERTAUTHSECRET")),
         ("<<rhorchata-origin-json>>", util.readFileAsString(util.getEnvVar("RHORCHATAORIGINJSON"))),
         ("<<gateway-origin-json>>", util.readFileAsString(util.getEnvVar("GATEWAYORIGINJSON"))),
+        ("<<FedRAMP-origin-json>>", util.readFileAsString(util.getEnvVar("FEDRAMPORIGINJSON")))
         ("<<turnpike-origin-json>>", util.readFileAsString(util.getEnvVar("TURNPIKEORIGINJSON"))),
         ("<<pentest-gateway-origin-json>>", util.readFileAsString(util.getEnvVar("PENTESTGATEWAYORIGINJSON"))),
         ("<<openshift-origin-json>>", util.readFileAsString(util.getEnvVar("OPENSHIFTORIGINJSON"))),


### PR DESCRIPTION
We would like to return html for gov.cloud.stage.redhat.com,
only route to cluster for /wss, /api, /r/insights. And it should
not return 301.

This PR is to remove the top level redirect and add origin routing.

JIRA: https://issues.redhat.com/browse/RHCLOUD-14061