### PR TITLE
Add origin for gov.cloud.stage.redhat.com

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,7 @@ node {
         withCredentials([
           file(credentialsId: "rhcs-akamai-edgerc", variable: 'EDGERC'),
           file(credentialsId: "rhcs-$ENVSTR-3scale-origin-json", variable: 'GATEWAYORIGINJSON'),
+          file(credentialsId: "rhcs-$ENVSTR-gov-3scale-origin-json", variable: 'FEDRAMPORIGINJSON'),
           file(credentialsId: "rhcs-$ENVSTR-turnpike-origin-json", variable: 'TURNPIKEORIGINJSON'),
           file(credentialsId: "rhcs-openshift-origin-json", variable: 'OPENSHIFTORIGINJSON'),
           file(credentialsId: "rhcs-openshift-mirror-origin-json", variable: 'OPENSHIFTORIGINMIRRORJSON'),

--- a/akamai/data/prod/base_rules.json
+++ b/akamai/data/prod/base_rules.json
@@ -1761,6 +1761,57 @@
                             }
                         ],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -1772,7 +1823,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -1812,12 +1862,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {
@@ -2069,6 +2113,57 @@
                         ],
                         "criteria": [],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -2231,7 +2326,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -2271,12 +2365,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {
@@ -2968,37 +3056,6 @@
                     }
                 ],
                 "name": "Client Cert"
-            },
-            {
-                "name": "Redirect Top Level for FedRAMP",
-                "children": [],
-                "behaviors": [
-                    {
-                        "name": "redirect",
-                        "options": {
-                            "queryString": "APPEND",
-                            "responseCode": 301,
-                            "destinationHostname": "OTHER",
-                            "destinationPath": "SAME_AS_REQUEST",
-                            "destinationProtocol": "SAME_AS_REQUEST",
-                            "mobileDefaultChoice": "DEFAULT",
-                            "destinationHostnameOther": "api-gateway-stage.apps.crcgovs02ue1.43j0.p1.openshiftapps.com"
-                        }
-                    }
-                ],
-                "criteria": [
-                    {
-                        "name": "hostname",
-                        "options": {
-                            "matchOperator": "IS_ONE_OF",
-                            "values": [
-                                "gov.cloud.redhat.com"
-                            ]
-                        }
-                    }
-                ],
-                "criteriaMustSatisfy": "all",
-                "comments": ""
             }
         ],
         "options": {

--- a/akamai/data/stage/base_rules.json
+++ b/akamai/data/stage/base_rules.json
@@ -1795,6 +1795,57 @@
                             }
                         ],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -1806,7 +1857,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -1846,12 +1896,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {
@@ -2086,6 +2130,57 @@
                         ],
                         "criteria": [],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -2214,7 +2309,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -2254,12 +2348,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {
@@ -2528,37 +2616,6 @@
                     }
                 ],
                 "name": "Client Cert"
-            },
-            {
-                "name": "Redirect Top Level",
-                "children": [],
-                "behaviors": [
-                    {
-                        "name": "redirect",
-                        "options": {
-                            "queryString": "APPEND",
-                            "responseCode": 301,
-                            "destinationHostname": "OTHER",
-                            "destinationPath": "SAME_AS_REQUEST",
-                            "destinationProtocol": "SAME_AS_REQUEST",
-                            "mobileDefaultChoice": "DEFAULT",
-                            "destinationHostnameOther": "api-gateway-stage.apps.crcgovs02ue1.43j0.p1.openshiftapps.com"
-                        }
-                    }
-                ],
-                "criteria": [
-                    {
-                        "name": "hostname",
-                        "options": {
-                            "matchOperator": "IS_ONE_OF",
-                            "values": [
-                                "gov.cloud.stage.redhat.com"
-                            ]
-                        }
-                    }
-                ],
-                "criteriaMustSatisfy": "all",
-                "comments": ""
             }
         ],
         "options": {

--- a/akamai/update_api.py
+++ b/akamai/update_api.py
@@ -100,6 +100,7 @@ def updatePropertyRulesUsingConfig(version_number, master_config_list, crc_env =
         ("<<certauth-gateway-secret>>", util.getEnvVar("CERTAUTHSECRET")),
         ("<<rhorchata-origin-json>>", util.readFileAsString(util.getEnvVar("RHORCHATAORIGINJSON"))),
         ("<<gateway-origin-json>>", util.readFileAsString(util.getEnvVar("GATEWAYORIGINJSON"))),
+        ("<<FedRAMP-origin-json>>", util.readFileAsString(util.getEnvVar("FEDRAMPORIGINJSON")))
         ("<<turnpike-origin-json>>", util.readFileAsString(util.getEnvVar("TURNPIKEORIGINJSON"))),
         ("<<pentest-gateway-origin-json>>", util.readFileAsString(util.getEnvVar("PENTESTGATEWAYORIGINJSON"))),
         ("<<openshift-origin-json>>", util.readFileAsString(util.getEnvVar("OPENSHIFTORIGINJSON"))),


### PR DESCRIPTION
We would like to return html for gov.cloud.stage.redhat.com,
only route to cluster for /wss, /api, /r/insights. And it should
not return 301.

This PR is to remove the top level redirect and add origin routing.

JIRA: https://issues.redhat.com/browse/RHCLOUD-14061