### PR TITLE
Add origin for gov.cloud.stage.redhat.com

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,7 @@ node {
         withCredentials([
           file(credentialsId: "rhcs-akamai-edgerc", variable: 'EDGERC'),
           file(credentialsId: "rhcs-$ENVSTR-3scale-origin-json", variable: 'GATEWAYORIGINJSON'),
+          file(credentialsId: "rhcs-$ENVSTR-gov-3scale-origin-json", variable: 'FEDRAMPORIGINJSON'),
           file(credentialsId: "rhcs-$ENVSTR-turnpike-origin-json", variable: 'TURNPIKEORIGINJSON'),
           file(credentialsId: "rhcs-openshift-origin-json", variable: 'OPENSHIFTORIGINJSON'),
           file(credentialsId: "rhcs-openshift-mirror-origin-json", variable: 'OPENSHIFTORIGINMIRRORJSON'),

--- a/akamai/data/prod/base_rules.json
+++ b/akamai/data/prod/base_rules.json
@@ -1816,6 +1816,27 @@
                             "headerValue": "cloud.redhat.com",
                             "customHeaderName": "x-rh-insights-forwarded-host"
                         }
+                    },
+                    {
+                        "name": "corsSupport",
+                        "options": {
+                            "enabled": true,
+                            "allowOrigins": "SPECIFIED",
+                            "allowCredentials": false,
+                            "allowHeaders": "ANY",
+                            "methods": [
+                                "GET",
+                                "PATCH",
+                                "POST",
+                                "PUT",
+                                "DELETE"
+                            ],
+                            "exposeHeaders": [],
+                            "preflightMaxAge": "600s",
+                            "origins": [
+                                "console.redhat.com"
+                            ]
+                        }
                     }
                 ],
                 "criteria": [
@@ -2324,6 +2345,27 @@
                         "name": "webSockets",
                         "options": {
                             "enabled": true
+                        }
+                    },
+                    {
+                        "name": "corsSupport",
+                        "options": {
+                            "enabled": true,
+                            "allowOrigins": "SPECIFIED",
+                            "allowCredentials": false,
+                            "allowHeaders": "ANY",
+                            "methods": [
+                                "GET",
+                                "PATCH",
+                                "POST",
+                                "PUT",
+                                "DELETE"
+                            ],
+                            "exposeHeaders": [],
+                            "preflightMaxAge": "600s",
+                            "origins": [
+                                "console.redhat.com"
+                            ]
                         }
                     }
                 ],

--- a/akamai/data/prod/base_rules.json
+++ b/akamai/data/prod/base_rules.json
@@ -1697,6 +1697,57 @@
                             }
                         ],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -1708,7 +1759,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -1748,12 +1798,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {
@@ -2156,6 +2200,57 @@
                         ],
                         "criteria": [],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -2167,7 +2262,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -2207,12 +2301,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {

--- a/akamai/data/stage/base_rules.json
+++ b/akamai/data/stage/base_rules.json
@@ -2008,6 +2008,27 @@
                             "headerValue": "internal.cloud.stage.redhat.com",
                             "customHeaderName": "x-rh-insights-forwarded-host"
                         }
+                    },
+                    {
+                        "name": "corsSupport",
+                        "options": {
+                            "enabled": true,
+                            "allowOrigins": "SPECIFIED",
+                            "allowCredentials": false,
+                            "allowHeaders": "ANY",
+                            "methods": [
+                                "GET",
+                                "PATCH",
+                                "POST",
+                                "PUT",
+                                "DELETE"
+                            ],
+                            "exposeHeaders": [],
+                            "preflightMaxAge": "600s",
+                            "origins": [
+                                "console.stage.redhat.com"
+                            ]
+                        }
                     }
                 ],
                 "criteria": [
@@ -2337,6 +2358,27 @@
                         "name": "allowTransferEncoding",
                         "options": {
                             "enabled": true
+                        }
+                    },
+                    {
+                        "name": "corsSupport",
+                        "options": {
+                            "enabled": true,
+                            "allowOrigins": "SPECIFIED",
+                            "allowCredentials": false,
+                            "allowHeaders": "ANY",
+                            "methods": [
+                                "GET",
+                                "PATCH",
+                                "POST",
+                                "PUT",
+                                "DELETE"
+                            ],
+                            "exposeHeaders": [],
+                            "preflightMaxAge": "600s",
+                            "origins": [
+                                "console.stage.redhat.com"
+                            ]
                         }
                     }
                 ],

--- a/akamai/data/stage/base_rules.json
+++ b/akamai/data/stage/base_rules.json
@@ -1731,6 +1731,57 @@
                             }
                         ],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -1742,7 +1793,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -1782,12 +1832,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {
@@ -2139,6 +2183,57 @@
                         ],
                         "criteria": [],
                         "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "gateway-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<gateway-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "cert.cloud.stage.redhat.com",
+                                        "cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "FedRAMP-origin",
+                        "children": [],
+                        "behaviors": [
+                            <<FedRAMP-origin-json>>,
+                            {
+                                "name": "caching",
+                                "options": {
+                                    "behavior": "NO_STORE"
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "hostname",
+                                "options": {
+                                    "matchOperator": "IS_ONE_OF",
+                                    "values": [
+                                        "gov.cloud.stage.redhat.com"
+                                    ]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all"
                     }
                 ],
                 "behaviors": [
@@ -2150,7 +2245,6 @@
                             "standardPassHeaderName": "OTHER"
                         }
                     },
-                    <<gateway-origin-json>>,
                     {
                         "name": "modifyOutgoingRequestHeader",
                         "options": {
@@ -2190,12 +2284,6 @@
                             "standardAddHeaderName": "OTHER",
                             "headerValue": "<<prod-gateway-secret>>",
                             "customHeaderName": "x-rh-insights-gateway-secret"
-                        }
-                    },
-                    {
-                        "name": "caching",
-                        "options": {
-                            "behavior": "NO_STORE"
                         }
                     },
                     {
@@ -2464,37 +2552,6 @@
                     }
                 ],
                 "name": "Client Cert"
-            },
-            {
-                "name": "Redirect Top Level",
-                "children": [],
-                "behaviors": [
-                    {
-                        "name": "redirect",
-                        "options": {
-                            "queryString": "APPEND",
-                            "responseCode": 301,
-                            "destinationHostname": "OTHER",
-                            "destinationPath": "SAME_AS_REQUEST",
-                            "destinationProtocol": "SAME_AS_REQUEST",
-                            "mobileDefaultChoice": "DEFAULT",
-                            "destinationHostnameOther": "api-gateway-stage.apps.crcgovs02ue1.43j0.p1.openshiftapps.com"
-                        }
-                    }
-                ],
-                "criteria": [
-                    {
-                        "name": "hostname",
-                        "options": {
-                            "matchOperator": "IS_ONE_OF",
-                            "values": [
-                                "gov.cloud.stage.redhat.com"
-                            ]
-                        }
-                    }
-                ],
-                "criteriaMustSatisfy": "all",
-                "comments": ""
             }
         ],
         "options": {

--- a/akamai/update_api.py
+++ b/akamai/update_api.py
@@ -100,7 +100,7 @@ def updatePropertyRulesUsingConfig(version_number, master_config_list, crc_env =
         ("<<certauth-gateway-secret>>", util.getEnvVar("CERTAUTHSECRET")),
         ("<<rhorchata-origin-json>>", util.readFileAsString(util.getEnvVar("RHORCHATAORIGINJSON"))),
         ("<<gateway-origin-json>>", util.readFileAsString(util.getEnvVar("GATEWAYORIGINJSON"))),
-        ("<<FedRAMP-origin-json>>", util.readFileAsString(util.getEnvVar("FEDRAMPORIGINJSON")))
+        ("<<FedRAMP-origin-json>>", util.readFileAsString(util.getEnvVar("FEDRAMPORIGINJSON"))),
         ("<<turnpike-origin-json>>", util.readFileAsString(util.getEnvVar("TURNPIKEORIGINJSON"))),
         ("<<pentest-gateway-origin-json>>", util.readFileAsString(util.getEnvVar("PENTESTGATEWAYORIGINJSON"))),
         ("<<openshift-origin-json>>", util.readFileAsString(util.getEnvVar("OPENSHIFTORIGINJSON"))),

--- a/akamai/update_api.py
+++ b/akamai/update_api.py
@@ -100,6 +100,7 @@ def updatePropertyRulesUsingConfig(version_number, master_config_list, crc_env =
         ("<<certauth-gateway-secret>>", util.getEnvVar("CERTAUTHSECRET")),
         ("<<rhorchata-origin-json>>", util.readFileAsString(util.getEnvVar("RHORCHATAORIGINJSON"))),
         ("<<gateway-origin-json>>", util.readFileAsString(util.getEnvVar("GATEWAYORIGINJSON"))),
+        ("<<FedRAMP-origin-json>>", util.readFileAsString(util.getEnvVar("FEDRAMPORIGINJSON")))
         ("<<turnpike-origin-json>>", util.readFileAsString(util.getEnvVar("TURNPIKEORIGINJSON"))),
         ("<<pentest-gateway-origin-json>>", util.readFileAsString(util.getEnvVar("PENTESTGATEWAYORIGINJSON"))),
         ("<<openshift-origin-json>>", util.readFileAsString(util.getEnvVar("OPENSHIFTORIGINJSON"))),


### PR DESCRIPTION
We would like to return html for gov.cloud.stage.redhat.com,
only route to cluster for /wss, /api, /r/insights. And it should
not return 301.

This PR is to remove the top level redirect and add origin routing.

JIRA: https://issues.redhat.com/browse/RHCLOUD-14061