### PR TITLE
Don't run smoke tests against the STAGE env

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,14 +21,10 @@ node {
       ENVSTR = "prod"
     } else if (BRANCH == "stage-stable") {
       PREFIX = ""
-      STAGETESTSTR = "\'stage and stable\'"
-      PRODTESTSTR = "\'prod and stable\'"
       RELEASESTR = "stable"
       ENVSTR = "stage"
     } else if (BRANCH == "stage-beta") {
       PREFIX = "beta/"
-      STAGETESTSTR = "\'stage and beta\'"
-      PRODTESTSTR = "\'prod and beta\'"
       RELEASESTR = "beta"
       ENVSTR = "stage"
     } else {
@@ -38,9 +34,11 @@ node {
     if (ENVSTR == "prod") {
       AKAMAI_APP_PATH = "/822386/${PREFIX}config"
       CSC_CONFIG_PATH = "https://cloud.redhat.com/${PREFIX}config"
+      RUN_SMOKE_TESTS = true
     } else {
       AKAMAI_APP_PATH = "/822386/${ENVSTR}/${PREFIX}config"
       CSC_CONFIG_PATH = "https://cloud.redhat.com/${ENVSTR}/${PREFIX}config"
+      RUN_SMOKE_TESTS = false   // cannot run smoke tests on stage as it requires vpn
     }
 
     sh "wget -O main.yml.bak ${CSC_CONFIG_PATH}/main.yml"
@@ -116,9 +114,14 @@ node {
 
   stage ("run akamai staging smoke tests") {
     try {
-      openShiftUtils.withNode {
-        sh "iqe plugin install akamai"
-        sh "IQE_AKAMAI_CERTIFI=true DYNACONF_AKAMAI=\'@json {\"release\":\"${RELEASESTR}\"}\' iqe tests plugin akamai -s -m ${STAGETESTSTR}"
+      if (RUN_SMOKE_TESTS) {
+        openShiftUtils.withNode {
+          sh "iqe plugin install akamai"
+          sh "IQE_AKAMAI_CERTIFI=true DYNACONF_AKAMAI=\'@json {\"release\":\"${RELEASESTR}\"}\' iqe tests plugin akamai -s -m ${STAGETESTSTR}"
+        }
+      }
+      else {
+        sh "echo Smoke tests cannot run against STAGE environment as it requires VPN connection"
       }
     } catch(e) {
       // If the tests don't all pass, roll back changes:
@@ -220,9 +223,14 @@ node {
 
   stage ("run akamai production smoke tests") {
     try {
-      openShiftUtils.withNode {
-        sh "iqe plugin install akamai"
-        sh "IQE_AKAMAI_CERTIFI=true DYNACONF_AKAMAI=\'@json {\"release\":\"${RELEASESTR}\"}\' iqe tests plugin akamai -s -m ${PRODTESTSTR}"
+      if (RUN_SMOKE_TESTS) {
+        openShiftUtils.withNode {
+          sh "iqe plugin install akamai"
+          sh "IQE_AKAMAI_CERTIFI=true DYNACONF_AKAMAI=\'@json {\"release\":\"${RELEASESTR}\"}\' iqe tests plugin akamai -s -m ${PRODTESTSTR}"
+        }
+      }
+      else {
+        sh "echo Smoke tests cannot run against STAGE environment as it requires VPN connection"
       }
     } catch(e) {
       // If the tests don't all pass, roll back changes:


### PR DESCRIPTION
Smoke tests make a GET request to a URL on c.rh.c. Our staging env (cloud.stage.redhat.com) requires a VPN connection. The Jenkins on which this Jenkinsfile runs is outside of VPN. Therefore, we cannot test the staging env. 

Furthermore, as they exist now, the smoke tests are hardcoded to test only production. The stage environment was introduced after the smoke tests were written. The smoke tests were never updated to cope with this change. The reason the tests against stage have passed up to this point is because they were actually running against the production environment. 

If we want to introduce smoke tests into the stage env the Jenkins cluster on which these run would need to be inside VPN. Or we'd need to leverage ephemeral envs in some way. 

For now I've disabled them. 