### PR TITLE
Add new Downloads page to OCM left navigation

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -18,6 +18,11 @@
             "title": "Releases"
         },
         {
+            "appId": "openshift",
+            "href": "/openshift/downloads",
+            "title": "Downloads"
+        },
+        {
             "groupId": "insights",
             "title": "Insights",
             "navItems": [


### PR DESCRIPTION
- [x] ~~Don't merge yet, the version currently in production https://cloud.redhat.com/openshift/downloads is older but we should get a good-to-launch version after today's OCM UI deploy~~...

https://issues.redhat.com/browse/SDA-4211