### PR TITLE
[qa-stable] Add Releases & Downloads pages to OCM left navigation

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -528,6 +528,12 @@ openshift:
       - id: overview
         title: Overview
         group: openshift
+      - id: releases
+        title: Releases
+        group: openshift
+      - id: downloads
+        title: Downloads
+        group: openshift
       - id: subscriptions
         title: Subscriptions
         section: insights


### PR DESCRIPTION
https://cloud.redhat.com/openshift/releases has long been in prod, I assume https://qaprodauth.cloud.redhat.com/openshift/releases omitted from qa-stable by oversight.

https://qaprodauth.cloud.redhat.com/openshift/downloads is a new page, adding here similar to #696.
(https://issues.redhat.com/browse/SDA-4211)