### PR TITLE
[prod-stable] Add new Downloads page to OCM left navigation

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -511,6 +511,9 @@ openshift:
       - id: releases
         title: Releases
         group: openshift
+      - id: downloads
+        title: Downloads
+        group: openshift
       - id: subscriptions
         title: Subscriptions
         section: insights


### PR DESCRIPTION
https://cloud.redhat.com/openshift/downloads is a new page, adding here similar to #696.
(https://issues.redhat.com/browse/SDA-4211)

Let's just check #701 and/or #702 worked before merging this.