### PR TITLE
[qa-beta] Add new Downloads page to OCM left navigation

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -18,6 +18,11 @@
             "title": "Releases"
         },
         {
+            "appId": "openshift",
+            "href": "/openshift/downloads",
+            "title": "Downloads"
+        },
+        {
             "groupId": "insights",
             "title": "Insights",
             "navItems": [

--- a/main.yml
+++ b/main.yml
@@ -620,6 +620,9 @@ openshift:
       - id: releases
         title: Releases
         group: openshift
+      - id: downloads
+        title: Downloads
+        group: openshift
       - id: ocp-advisor
         group: insights
       - id: subscriptions


### PR DESCRIPTION
https://qaprodauth.cloud.redhat.com/beta/openshift/downloads is a new page, adding here similar to #696.
(https://issues.redhat.com/browse/SDA-4211)

@karelhala @Hyperkid123 I'm not sure whether this PR is right/needed, as README claims there is automatic ci-beta -> nightly-beta -> qa-beta -> stage-beta sync, but I see nightly-beta and qa-beta haven't updated recently?
[This is not urgent at all, we almost never use qaprodauth/beta :see_no_evil:]

Also, I only now noticed that ci-beta had both main.yml and openshift-navigation.json.  In #696 I only updated the latter, here updating both.  Should I go back and update main.yml on ci-beta first?