### PR TITLE
Add a symlink to insights-navigation.json file

### DIFF
--- a/chrome/insights-navigation.json
+++ b/chrome/insights-navigation.json
@@ -1,0 +1,1 @@
+rhel-navigation.json


### PR DESCRIPTION
Dunno why was this reverted https://github.com/RedHatInsights/cloud-services-config/pull/735 but we could use the changes from https://github.com/RedHatInsights/insights-chrome/pull/1505 which drops the mapper.

Symlink will be required until we move insights to rhel.

cc @redallen @karelhala 