### PR TITLE
Revert "Revert "add cloud tutorials to nav, rename rhel-navigation to…

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -534,5 +534,17 @@
                 ]
             }
         ]
+    },
+    "cloudTutorials": {
+        "manifestLocation": "/apps/cloud-tutorials/fed-mods.json",
+        "modules": [
+            {
+                "id": "cloud-tutorials",
+                "module": "./RootApp",
+                "routes": [
+                    "/mosaic/cloud-tutorials"
+                ]
+            }
+        ]
     }
 }

--- a/chrome/mosaic-navigation.json
+++ b/chrome/mosaic-navigation.json
@@ -1,0 +1,11 @@
+{
+    "id": "mosaic",
+    "title": "Cloud Tutorials",
+    "navItems": [
+        {
+            "title": "Cloud Tutorials",
+            "appId": "cloudTutorials",
+            "href": "/mosaic/cloud-tutorials"
+        }
+    ]
+}

--- a/chrome/validate-nav.js
+++ b/chrome/validate-nav.js
@@ -6,16 +6,15 @@ const navigationSchema = require('./validationSchemas/navigation');
 
 
 
-const navigationFiles = ['ansible', 'application-services', 'rhel', 'settings', 'user-preferences', 'openshift'].map((file) => path.resolve(__dirname, `${file}-navigation.json`))
+const navigationFiles = fs.readdirSync(__dirname)
+  .filter(f => f.endsWith('-navigation.json') && f !== 'landing-navigation.json');
 const landingFile = path.resolve(__dirname, 'landing-navigation.json')
 const modulesFile = path.resolve(__dirname, 'fed-modules.json')
 
 
 async function validateLanding() {    
   try {
-    const file = fs.readFileSync(landingFile, {
-      encoding: 'utf-8'
-    })
+    const file = fs.readFileSync(landingFile, 'utf-8')
     await landingSchema.strict(true).validateAsync(JSON.parse(file));
   } catch (error) {
     console.error(`Error in landing page navigation definition.\n`, error)
@@ -25,9 +24,7 @@ async function validateLanding() {
 
 async function validateModules() {
   try {
-    const file = fs.readFileSync(modulesFile, {
-      encoding: 'utf-8'
-    })
+    const file = fs.readFileSync(modulesFile, 'utf-8')
     await modulesSchema.strict(true).validateAsync(JSON.parse(file));
   } catch (error) {
     console.error(`Error in federated modules definition.\n`, error)
@@ -37,16 +34,14 @@ async function validateModules() {
 
 async function validateNavigation() {
   navigationFiles.forEach(async fileName => {
-    const file = fs.readFileSync(fileName, {
-      encoding: 'utf-8'
-    })
+    const file = fs.readFileSync(path.join(__dirname, fileName), 'utf-8')
     try {
-        const result = await navigationSchema.strict(true).validateAsync(JSON.parse(file));
+      const result = await navigationSchema.strict(true).validateAsync(JSON.parse(file));
     } catch (error) {
-        console.error(`Error in ${fileName} navigation definition.\n`, error)
-        process.exit(1)
+      console.error(`Error in ${fileName} navigation definition.\n`, error)
+      process.exit(1)
     }
-})
+  })
 }
 
 validateLanding()

--- a/main.yml
+++ b/main.yml
@@ -223,6 +223,10 @@ cloud-tutorials:
     versions:
       -v1
   frontend:
+    module:
+      appName: cloud-tutorials
+      scope: cloudTutorials
+      module: ./RootApp
     title: Cloud Tutorials
     paths:
       - /mosaic/cloud-tutorials


### PR DESCRIPTION
… insights-navigation (#735)" (#737)"

This reverts commit ba8431b88209ca4e7135f80116ce732d3e1c0f54. It turns out the symlink was not the reason ci/qa crashed and started 404ing. The symlink is actually currently working: https://ci.cloud.redhat.com/beta/config/chrome/insights-navigation.json