### PR TITLE
[ci-stable] Add in 3scale smoke tests with authentication

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,8 +117,23 @@ node {
     try {
       if (RUN_SMOKE_TESTS) {
         openShiftUtils.withNode {
-          sh "iqe plugin install akamai"
-          sh "IQE_AKAMAI_CERTIFI=true DYNACONF_AKAMAI=\'@json {\"release\":\"${RELEASESTR}\"}\' iqe tests plugin akamai -s -m ${STAGETESTSTR}"
+          withCredentials([
+            string(credentialsId: "vaultRoleId", variable: 'DYNACONF_IQE_VAULT_ROLE_ID'),
+            string(credentialsId: "vaultSecretId", variable: 'DYNACONF_IQE_VAULT_SECRET_ID'),
+          ]) {
+            // set some env variables for authentication in the iqe-core pod
+            withEnv([
+              "DYNACONF_IQE_VAULT_ROLE_ID=$DYNACONF_IQE_VAULT_ROLE_ID",
+              "DYNACONF_IQE_VAULT_SECRET_ID=$DYNACONF_IQE_VAULT_SECRET_ID",
+              "DYNACONF_IQE_VAULT_LOADER_ENABLED=true",
+              "ENV_FOR_DYNACONF=prod"
+            ]) {
+              // install akamai and 3scale plugins, run smoke tests
+              sh "iqe plugin install akamai 3scale"
+              sh "IQE_AKAMAI_CERTIFI=true DYNACONF_AKAMAI=\'@json {\"release\":\"${RELEASESTR}\"}\' iqe tests plugin akamai -s -m ${STAGETESTSTR}"
+              sh "iqe tests plugin 3scale --akamai-staging -m akamai_smoke"
+            }
+          }
         }
       }
       else {
@@ -226,8 +241,23 @@ node {
     try {
       if (RUN_SMOKE_TESTS) {
         openShiftUtils.withNode {
-          sh "iqe plugin install akamai"
-          sh "IQE_AKAMAI_CERTIFI=true DYNACONF_AKAMAI=\'@json {\"release\":\"${RELEASESTR}\"}\' iqe tests plugin akamai -s -m ${PRODTESTSTR}"
+          withCredentials([
+            string(credentialsId: "vaultRoleId", variable: 'DYNACONF_IQE_VAULT_ROLE_ID'),
+            string(credentialsId: "vaultSecretId", variable: 'DYNACONF_IQE_VAULT_SECRET_ID'),
+          ]) {
+            // set some env variables for authentication in the iqe-core pod
+            withEnv([
+              "DYNACONF_IQE_VAULT_ROLE_ID=$DYNACONF_IQE_VAULT_ROLE_ID",
+              "DYNACONF_IQE_VAULT_SECRET_ID=$DYNACONF_IQE_VAULT_SECRET_ID",
+              "DYNACONF_IQE_VAULT_LOADER_ENABLED=true",
+              "ENV_FOR_DYNACONF=prod"
+            ]) {
+              // install akamai and 3scale plugins, run smoke tests
+              sh "iqe plugin install akamai 3scale"
+              sh "IQE_AKAMAI_CERTIFI=true DYNACONF_AKAMAI=\'@json {\"release\":\"${RELEASESTR}\"}\' iqe tests plugin akamai -s -m ${PRODTESTSTR}"
+              sh "iqe tests plugin 3scale --akamai-production -m akamai_smoke"
+            }
+          }
         }
       }
       else {


### PR DESCRIPTION
* Add 3scale smoke tests
* Use Jenkins creds to enable the vault loader in IQE

This work is for https://issues.redhat.com/browse/RHCLOUD-14994

I've tested this PR by creating a new job in Jenkins (cf. `test-csc-deploy-pipeline` build no. `1` to view it) that just runs the smoke tests to verify that the authentication is working.