### PR TITLE
[prod-stable] Add in 3scale smoke tests with authentication

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,14 +21,10 @@ node {
       ENVSTR = "prod"
     } else if (BRANCH == "stage-stable") {
       PREFIX = ""
-      STAGETESTSTR = "\'stage and stable\'"
-      PRODTESTSTR = "\'prod and stable\'"
       RELEASESTR = "stable"
       ENVSTR = "stage"
     } else if (BRANCH == "stage-beta") {
       PREFIX = "beta/"
-      STAGETESTSTR = "\'stage and beta\'"
-      PRODTESTSTR = "\'prod and beta\'"
       RELEASESTR = "beta"
       ENVSTR = "stage"
     } else {
@@ -38,9 +34,11 @@ node {
     if (ENVSTR == "prod") {
       AKAMAI_APP_PATH = "/822386/${PREFIX}config"
       CSC_CONFIG_PATH = "https://cloud.redhat.com/${PREFIX}config"
+      RUN_SMOKE_TESTS = true
     } else {
       AKAMAI_APP_PATH = "/822386/${ENVSTR}/${PREFIX}config"
       CSC_CONFIG_PATH = "https://cloud.redhat.com/${ENVSTR}/${PREFIX}config"
+      RUN_SMOKE_TESTS = false   // cannot run smoke tests on stage as it requires vpn
     }
 
     sh "wget -O main.yml.bak ${CSC_CONFIG_PATH}/main.yml"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,6 +131,7 @@ node {
               // install akamai and 3scale plugins, run smoke tests
               sh "iqe plugin install akamai 3scale"
               sh "IQE_AKAMAI_CERTIFI=true DYNACONF_AKAMAI=\'@json {\"release\":\"${RELEASESTR}\"}\' iqe tests plugin akamai -s -m ${STAGETESTSTR}"
+              sh "iqe tests plugin akamai -k 'test_api.py' -m stage"
               sh "iqe tests plugin 3scale --akamai-staging -m akamai_smoke"
             }
           }
@@ -251,6 +252,7 @@ node {
               // install akamai and 3scale plugins, run smoke tests
               sh "iqe plugin install akamai 3scale"
               sh "IQE_AKAMAI_CERTIFI=true DYNACONF_AKAMAI=\'@json {\"release\":\"${RELEASESTR}\"}\' iqe tests plugin akamai -s -m ${PRODTESTSTR}"
+              sh "iqe tests plugin akamai -k 'test_api.py' -m prod"
               sh "iqe tests plugin 3scale --akamai-production -m akamai_smoke"
             }
           }


### PR DESCRIPTION
* Add 3scale smoke tests
* Use Jenkins creds to enable the vault loader in IQE

This work is for https://issues.redhat.com/browse/RHCLOUD-14994

I've tested this PR by creating a new job in Jenkins (cf. `test-csc-deploy-pipeline` build no. `1` to view it) that just runs the smoke tests to verify that the authentication is working.