### PR TITLE
Temporarily disable QA backup for navigation schemas.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,8 @@ node {
 
     sh "wget -O main.yml.bak ${CSC_CONFIG_PATH}/main.yml"
     sh "wget -O releases.yml.bak ${CSC_CONFIG_PATH}/releases.yml"
-    sh "wget -r -np -A \"*.json\" -nd ${CSC_CONFIG_PATH}/chrome/ -P ./chrome.bak"
+    // we have to wait with the backup after first upload to akamai
+    // sh "wget -r -np -A \"*.json\" -nd ${CSC_CONFIG_PATH}/chrome/ -P ./chrome.bak"
   }
 
   stage ("build & activate on Akamai staging") {
@@ -147,8 +148,9 @@ node {
         sh "cp main.yml.bak main.yml"
         sh "rm releases.yml"
         sh "cp releases.yml.bak releases.yml"
-        sh "rm -r chrome"
-        sh "cp -r chrome.bak chrome"
+        // we have to wait with the backup after first upload to akamai
+        // sh "rm -r chrome"
+        // sh "cp -r chrome.bak chrome"
         withCredentials(bindings: [sshUserPrivateKey(credentialsId: "cloud-netstorage",
                 keyFileVariable: "privateKeyFile",
                 passphraseVariable: "",
@@ -271,8 +273,9 @@ node {
         sh "cp main.yml.bak main.yml"
         sh "rm releases.yml"
         sh "cp releases.yml.bak releases.yml"
-        sh "rm -r chrome"
-        sh "cp -r chrome.bak chrome"
+        // we have to wait with the backup after first upload to akamai
+        // sh "rm -r chrome"
+        // sh "cp -r chrome.bak chrome"
         withCredentials(bindings: [sshUserPrivateKey(credentialsId: "cloud-netstorage",
                 keyFileVariable: "privateKeyFile",
                 passphraseVariable: "",


### PR DESCRIPTION
Jenkins is dying in stage-beta because it's trying to backup the new JSON files but there are none so the request ends up throwing 404 and crashes the whole process.

cc @john-dupuy 