### PR TITLE
Remove starter from staging navigation (ci-stable)

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -426,18 +426,6 @@
             }
         ]
     },
-    "starter": {
-        "manifestLocation": "/apps/starter/fed-mods.json",
-        "modules": [
-            {
-                "id": "starter",
-                "module": "./RootApp",
-                "routes": [
-                    "/staging/starter"
-                ]
-            }
-        ]
-    },
     "ruledev": {
         "dynamic": false,
         "modules": [

--- a/chrome/staging-navigation.json
+++ b/chrome/staging-navigation.json
@@ -3,11 +3,6 @@
     "title": "Staging Bundle;",
     "navItems": [
         {
-            "title": "Commit Tracker",
-            "appId": "starter",
-            "href": "/staging/starter"
-        },
-        {
             "title": "Access Requests",
             "appId": "ruledev",
             "href": "/staging/ruledev"


### PR DESCRIPTION
Removed unnecessary starter app from `staging-navigation.json`