### PR TITLE
[qa-beta] Remove duplicate downloads nav entry.

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -30,11 +30,6 @@
             "product": "Red Hat OpenShift Cluster Manager"
         },
         {
-            "appId": "openshift",
-            "href": "/openshift/downloads",
-            "title": "Downloads"
-        },
-        {
             "groupId": "insights",
             "title": "Insights",
             "navItems": [


### PR DESCRIPTION
For some reason the branch is out of sync with ci-beta and contains duplicate nav entry in openshift schema.