### PR TITLE
Remove My namespaces from Automation hub navigation

### DIFF
--- a/chrome/ansible-navigation.json
+++ b/chrome/ansible-navigation.json
@@ -26,12 +26,6 @@
                 },
                 {
                     "appId": "ansibleAutomationHub",
-                    "title": "My Namespaces",
-                    "href": "/ansible/automation-hub/automation-my-namespaces",
-                    "product": "Ansible Automation Hub"
-                },
-                {
-                    "appId": "ansibleAutomationHub",
                     "title": "Repo Management",
                     "href": "/ansible/automation-hub/automation-repositories",
                     "product": "Ansible Automation Hub"


### PR DESCRIPTION
Automation hub needs to remove My namespaces because it moved from navigation to tabs on Partners page.

cc: @newswangerd 
