### PR TITLE
Remove My namespaces from Automation hub navigation

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -162,8 +162,6 @@ automation-hub:
         default: true
       - id: partners
         title: Partners
-      - id: my-namespaces
-        title: My namespaces
       - id: repositories
         title: Repo Management
       - id: token


### PR DESCRIPTION
Automation hub needs to remove My namespaces because it moved from navigation to tabs on Partners page.

https://github.com/RedHatInsights/cloud-services-config/pull/762#issuecomment-879123304