### PR TITLE
Remove extra prefix from Automation Hub's hrefs and add missing slash

### DIFF
--- a/chrome/ansible-navigation.json
+++ b/chrome/ansible-navigation.json
@@ -15,25 +15,25 @@
                 {
                     "appId": "ansibleAutomationHub",
                     "title": "Collections",
-                    "href": "/ansible/automation-hub",
+                    "href": "/ansible/automation-hub/",
                     "product": "Ansible Automation Hub"
                 },
                 {
                     "appId": "ansibleAutomationHub",
                     "title": "Partners",
-                    "href": "/ansible/automation-hub/automation-partners",
+                    "href": "/ansible/automation-hub/partners",
                     "product": "Ansible Automation Hub"
                 },
                 {
                     "appId": "ansibleAutomationHub",
                     "title": "Repo Management",
-                    "href": "/ansible/automation-hub/automation-repositories",
+                    "href": "/ansible/automation-hub/repositories",
                     "product": "Ansible Automation Hub"
                 },
                 {
                     "appId": "ansibleAutomationHub",
                     "title": "Connect to Hub",
-                    "href": "/ansible/automation-hub/automation-token",
+                    "href": "/ansible/automation-hub/token",
                     "product": "Ansible Automation Hub"
                 }
             ]


### PR DESCRIPTION
Related to https://github.com/RedHatInsights/cloud-services-config/pull/784