### PR TITLE
[ci-beta] Change Cluster Management to Clusters

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -5,7 +5,7 @@
         {
             "appId": "openshift",
             "href": "/openshift",
-            "title": "Cluster Management",
+            "title": "Clusters",
             "product": "Red Hat OpenShift Cluster Manager"
         },
         {


### PR DESCRIPTION
- In every pre-prod stable env, `Clusters` is in the App Filter.
- In prod-stable and prod-beta, `Clusters` is in the App Filter.
- Every pre-prod beta env has `Cluster Management` in the App Filter

Based on the mocks in https://issues.redhat.com/browse/RHCLOUD-13888, it should be `Clusters` in the pre-prod beta envs. 

cc @Hyperkid123 
