### PR TITLE
[qa-stable] Remove /openshift/overview override

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -126,18 +126,6 @@
             }
         ]
     },
-    "openshiftOverview": {
-        "dynamic": false,
-        "modules": [
-            {
-                "id": "openshiftOverview",
-                "dynamic": false,
-                "routes": [
-                    "/openshift/overview"
-                ]
-            }
-        ]
-    },
     "costManagement": {
         "manifestLocation": "/apps/cost-management/fed-mods.json",
         "modules": [


### PR DESCRIPTION
The Overview section is rendered by OCM app.  Now that we enabled chrome v2 in OCM, we think this currently causes Overview screen not to mount in stage & prod.
![image](https://user-images.githubusercontent.com/273688/127455081-786367ed-8d4c-47e1-bc61-fb1eb1b9ccaf.png)

https://issues.redhat.com/browse/SDA-4552

cc @elad661