### PR TITLE
[ci-beta] Add additional apps to ansible bundle.

### DIFF
--- a/chrome/ansible-navigation.json
+++ b/chrome/ansible-navigation.json
@@ -95,21 +95,10 @@
             ]
         },
         {
-            "groupId": "insights",
-            "title": "Insights",
+            "groupId": "operations",
+            "icon": "wrench",
+            "title": "Operations Insights",
             "navItems": [
-                {
-                    "appId": "automationAnalytics",
-                    "title": "Savings Planner",
-                    "href": "/ansible/insights/savings-planner",
-                    "product": "Ansible Automation Analytics"
-                },
-                {
-                    "appId": "automationAnalytics",
-                    "title": "Automation Calculator",
-                    "href": "/ansible/insights/automation-calculator",
-                    "product": "Ansible Automation Analytics"
-                },
                 {
                     "appId": "automationAnalytics",
                     "title": "Organization Statistics",
@@ -129,10 +118,102 @@
                     "product": "Ansible Automation Analytics"
                 },
                 {
+                    "title": "Advisor",
+                    "expandable": true,
+                    "routes": [
+                        {
+                            "appId": "advisor",
+                            "title": "Recommendations",
+                            "href": "/ansible/advisor/recommendations",
+                            "product": "Red Hat Insights"
+                        },
+                        {
+                            "appId": "advisor",
+                            "title": "Systems",
+                            "href": "/ansible/advisor/systems",
+                            "product": "Red Hat Insights"
+                        },
+                        {
+                            "appId": "approval",
+                            "title": "Topics",
+                            "href": "/ansible/advisor/topics",
+                            "product": "Red Hat Insights"
+                        }
+                    ]
+                },
+                {
+                    "title": "Drift",
+                    "expandable": true,
+                    "routes": [
+                        {
+                            "appId": "drift",
+                            "title": "Comparison",
+                            "href": "/ansible/drift/",
+                            "product": "Red Hat Insights"
+                        },
+                        {
+                            "appId": "drift",
+                            "title": "Baselines",
+                            "href": "/ansible/drift/baselines",
+                            "product": "Red Hat Insights"
+                        }
+                    ]
+                },
+                {
+                    "appId": "inventory",
+                    "title": "Inventory",
+                    "href": "/ansible/inventory",
+                    "product": "Red Hat Insights"
+                }
+            ]
+        },
+        {
+            "groupId": "security",
+            "icon": "shield",
+            "title": "Security Insights",
+            "navItems": [
+                {
+                    "appId": "policies",
+                    "title": "Policies",
+                    "href": "/ansible/policies"
+                }
+            ]
+        },
+        {
+            "groupId": "business",
+            "icon": "trend-up",
+            "title": "Business Insights",
+            "navItems": [
+                {
+                    "appId": "automationAnalytics",
+                    "title": "Savings Planner",
+                    "href": "/ansible/insights/savings-planner",
+                    "product": "Ansible Automation Analytics"
+                },
+                {
+                    "appId": "automationAnalytics",
+                    "title": "Automation Calculator",
+                    "href": "/ansible/insights/automation-calculator",
+                    "product": "Ansible Automation Analytics"
+                },
+                {
                     "appId": "automationAnalytics",
                     "title": "Notifications",
                     "href": "/ansible/insights/notifications",
                     "product": "Ansible Automation Analytics"
+                },
+                {
+                    "appId": "registration",
+                    "title": "Register Systems",
+                    "filterable": false,
+                    "href": "/ansible/insights/registration",
+                    "product": "Red Hat Insights"
+                },
+                {
+                    "appId": "remediations",
+                    "title": "Remediations",
+                    "href": "/ansible/insights/remediations",
+                    "product": "Red Hat Insights"
                 }
             ]
         },

--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -182,7 +182,8 @@
                 "id": "advisor",
                 "module": "./RootApp",
                 "routes": [
-                    "/insights/advisor"
+                    "/insights/advisor",
+                    "/ansible/advisor"
                 ]
             }
         ]
@@ -206,7 +207,8 @@
                 "id": "drift",
                 "module": "./RootApp",
                 "routes": [
-                    "/insights/drift"
+                    "/insights/drift",
+                    "/ansible/drift"
                 ]
             }
         ]
@@ -218,7 +220,8 @@
                 "id": "inventory",
                 "module": "./RootApp",
                 "routes": [
-                    "/insights/inventory"
+                    "/insights/inventory",
+                    "/ansible/inventory"
                 ]
             }
         ]
@@ -254,7 +257,8 @@
                 "id": "policies",
                 "module": "./RootApp",
                 "routes": [
-                    "/insights/policies"
+                    "/insights/policies",
+                    "/ansible/policies"
                 ]
             }
         ]
@@ -325,7 +329,8 @@
                 "id": "registration",
                 "module": "./RootApp",
                 "routes": [
-                    "/insights/registration"
+                    "/insights/registration",
+                    "/ansible/registration"
                 ]
             }
         ]
@@ -337,7 +342,8 @@
                 "id": "remediations",
                 "module": "./RootApp",
                 "routes": [
-                    "/insights/remediations"
+                    "/insights/remediations",
+                    "/ansible/remediations"
                 ]
             }
         ]


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-15242

note: new applications do not have their routing setup to use `/ansible/insights`, therefore we will hook them directly to `/ansible`. For example instead of `/ansible/insights/advisor` we will use `/ansible/advisor`. This can be easily changed once the applications adjust their router basename based on the current application.


### Preview:
(ignore the xxx in the nav title, it was just for testing)
![screenshot-ci foo redhat com_1337-2021 08 03-09_32_35](https://user-images.githubusercontent.com/22619452/127976026-b6ae9e1e-ef12-44b1-8168-20efeea0bfd1.png)

