### PR TITLE
Hide RHEL for edge in app finder

### DIFF
--- a/chrome/edge-navigation.json
+++ b/chrome/edge-navigation.json
@@ -5,6 +5,7 @@
         {
             "title": "Fleet Management",
             "appId": "edge",
+            "filterable": false,
             "href": "/edge/fleet-management",
             "permissions": [
                 {
@@ -16,6 +17,7 @@
         {
             "title": "Manage images",
             "appId": "edge",
+            "filterable": false,
             "href": "/edge/manage-images",
             "permissions": [
                 {


### PR DESCRIPTION
Hide RHEL for edge in app finder to resolve ticket [RHELPLAN-88724](https://issues.redhat.com/browse/RHELPLAN-88724).