### PR TITLE
[ci/beta, qa/beta] Show OCP Advisor application in the nav panel

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -36,7 +36,6 @@
                 {
                     "title": "Advisor",
                     "expandable": true,
-                    "isHidden": true,
                     "routes": [
                         {
                             "appId": "ocpAdvisor",

--- a/main.yml
+++ b/main.yml
@@ -663,7 +663,6 @@ ocp-advisor:
   deployment_repo: https://github.com/RedHatInsights/ocp-advisor-frontend-build
   frontend:
     module: ocp-advisor#./RootApp
-    isHidden: true
     paths:
       - /openshift/insights/advisor
     sub_apps:


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-5017.

There were some updates to the app OCP Advisor and we now need to start showing OCP Advisor application in ci/beta and qa/beta environments.