### PR TITLE
[prod/beta] Show OCP Advisor application in the nav panel

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -34,6 +34,24 @@
             "title": "Insights",
             "navItems": [
                 {
+                    "title": "Advisor",
+                    "expandable": true,
+                    "routes": [
+                        {
+                            "appId": "ocpAdvisor",
+                            "title": "Clusters",
+                            "href": "/openshift/insights/advisor/clusters",
+                            "product": "Red Hat OpenShift Cluster Manager"
+                        },
+                        {
+                            "appId": "ocpAdvisor",
+                            "title": "Recommendations",
+                            "href": "/openshift/insights/advisor/recommendations",
+                            "product": "Red Hat OpenShift Cluster Manager"
+                        }
+                    ]
+                },
+                {
                     "title": "Subscriptions",
                     "expandable": true,
                     "routes": [

--- a/main.yml
+++ b/main.yml
@@ -640,7 +640,6 @@ ocp-advisor:
   deployment_repo: https://github.com/RedHatInsights/ocp-advisor-frontend-build
   frontend:
     module: ocp-advisor#./RootApp
-    isHidden: true
     paths:
       - /openshift/insights/advisor
     sub_apps:


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-5017.

There were some updates to the app OCP Advisor and we now need to start showing OCP Advisor application in ci/beta and qa/beta environments.