### PR TITLE
[ci-beta] Mark commit tracker as chrome 2 ready.

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -56,11 +56,11 @@
         ]
     },
     "commitTracker": {
-        "dynamic": false,
+        "manifestLocation": "/apps/commit-tracker/fed-mods.json",
         "modules": [
             {
                 "id": "commit-tracker",
-                "dynamic": false,
+                "module": "./RootApp",
                 "routes": [
                     "/internal",
                     "/internal/commit-tracker"


### PR DESCRIPTION
Commit tracker is one of the last apps not using chrome. We will be discontinuing chrome 1 functionality soon.

cc @psav 