### PR TITLE
[prod-stable] Add OpenShift notification settings and user preferences

### DIFF
--- a/chrome/settings-navigation.json
+++ b/chrome/settings-navigation.json
@@ -51,6 +51,11 @@
                     "appId": "notifications",
                     "title": "Red Hat Enterprise Linux",
                     "href": "/settings/notifications/rhel"
+                },
+                {
+                    "appId": "notifications",
+                    "title": "OpenShift",
+                    "href": "/settings/notifications/openshift"
                 }
             ]
         },

--- a/chrome/user-preferences-navigation.json
+++ b/chrome/user-preferences-navigation.json
@@ -15,6 +15,11 @@
                     "appId": "userPreferences",
                     "title": "Red Hat Enterprise Linux",
                     "href": "/user-preferences/notifications/rhel"
+                },
+                {
+                    "appId": "userPreferences",
+                    "title": "OpenShift",
+                    "href": "/user-preferences/notifications/openshift"
                 }
             ]
         }


### PR DESCRIPTION
Enable OpenShift notification settings and user preferences in prod.
These features have been tested and improved during the last month, and are ready for GA