### PR TITLE
Add Subscription Inventory

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -307,6 +307,18 @@
             }
         ]
     },
+    "subscriptionInventory": {
+        "manifestLocation": "/apps/subscription-inventory/fed-mods.json",
+        "modules": [
+            {
+                "id": "subscription-inventory",
+                "module": "./RootApp",
+                "routes": [
+                    "/insights/subscriptions/inventory"
+                ]
+            }
+        ]
+    },
     "manifests": {
         "manifestLocation": "/apps/manifests/fed-mods.json",
         "modules": [

--- a/chrome/rhel-navigation.json
+++ b/chrome/rhel-navigation.json
@@ -212,6 +212,12 @@
                             "product": "Subscription Watch"
                         },
                         {
+                            "appId": "subscription-inventory",
+                            "title": "Subscription Inventory",
+                            "href": "/insights/subscriptions/inventory",
+                            "product": "Subscription Watch"
+                        },
+                        {
                             "appId": "manifests",
                             "title": "Manifests",
                             "href": "/insights/subscriptions/manifests",

--- a/chrome/rhel-navigation.json
+++ b/chrome/rhel-navigation.json
@@ -212,7 +212,7 @@
                             "product": "Subscription Watch"
                         },
                         {
-                            "appId": "subscription-inventory",
+                            "appId": "subscriptionInventory",
                             "title": "Subscription Inventory",
                             "href": "/insights/subscriptions/inventory",
                             "product": "Subscription Watch"

--- a/main.yml
+++ b/main.yml
@@ -549,6 +549,20 @@ malware:
         title: Systems
   source_repo: https://github.com/RedHatInsights/malware-detection-frontend
 
+subscription-inventory:
+  title: Subscription Inventory
+  channel: '#subscription-inventory'
+  deployment_repo: https://github.com/RedHatInsights/subscription-inventory-ui-build
+  frontend:
+    module:
+      appName: subscription-inventory
+      scope: inventory
+      module: ./RootApp
+    paths:
+      - /insights/subscriptions/inventory
+    reload: subscriptions/inventory
+  source_repo: https://github.com/RedHatInsights/subscription-inventory-ui
+
 manifests:
   title: Manifests
   channel: '#subscription-central'

--- a/main.yml
+++ b/main.yml
@@ -553,14 +553,6 @@ subscription-inventory:
   title: Subscription Inventory
   channel: '#subscription-inventory'
   deployment_repo: https://github.com/RedHatInsights/subscription-inventory-ui-build
-  frontend:
-    module:
-      appName: subscription-inventory
-      scope: inventory
-      module: ./RootApp
-    paths:
-      - /insights/subscriptions/inventory
-    reload: subscriptions/inventory
   source_repo: https://github.com/RedHatInsights/subscription-inventory-ui
 
 manifests:


### PR DESCRIPTION
I'm working on adding a new "Subscription Inventory" app.  I'm still working on pushing up deploy-able code for it, but I wanted to go ahead and get this config in place.   I tried to make the config match our Subscription Manifest config as best I could, but I couldn't follow the same appId naming convention and maintain the path we want because the "inventory" appId was already taken.