### PR TITLE
update application settings;

### DIFF
--- a/chrome/settings-navigation.json
+++ b/chrome/settings-navigation.json
@@ -78,15 +78,6 @@
         {
             "title": "Applications",
             "expandable": true,
-            "permissions": [
-                {
-                    "method": "isEntitled",
-                    "args": [
-                        "insights",
-                        "cost_management"
-                    ]
-                }
-            ],
             "routes": [
                 {
                     "appId": "applications",

--- a/chrome/settings-navigation.json
+++ b/chrome/settings-navigation.json
@@ -80,10 +80,10 @@
             "expandable": true,
             "permissions": [
                 {
-                    "method": "isOrgAdmin",
-                    "apps": [
-                        "cost-management",
-                        "insights"
+                    "method": "isEntitled",
+                    "args": [
+                        "insights",
+                        "cost-management"
                     ]
                 }
             ],

--- a/chrome/settings-navigation.json
+++ b/chrome/settings-navigation.json
@@ -83,7 +83,7 @@
                     "method": "isEntitled",
                     "args": [
                         "insights",
-                        "cost-management"
+                        "cost_management"
                     ]
                 }
             ],

--- a/chrome/settings-navigation.json
+++ b/chrome/settings-navigation.json
@@ -82,7 +82,8 @@
                 {
                     "method": "isOrgAdmin",
                     "apps": [
-                        "cost-management"
+                        "cost-management",
+                        "insights"
                     ]
                 }
             ],
@@ -97,6 +98,14 @@
                             "args": [
                                 "insights"
                             ]
+                        },
+                        {
+                            "method": "hasPermissions",
+                            "args": [
+                                [
+                                    "advisor:*:*"
+                                ]
+                            ]
                         }
                     ]
                 },
@@ -109,6 +118,14 @@
                             "method": "isEntitled",
                             "args": [
                                 "cost_management"
+                            ]
+                        },
+                        {
+                            "method": "hasPermissions",
+                            "args": [
+                                [
+                                    "cost-management:*:*"
+                                ]
                             ]
                         }
                     ]


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-15888

> A non-org admin user should be able to access whatever apps exist in the Applications section if they have the correct RBAC permissions. We should stop gating this nav item by org admin checks and only check for RBAC. 
> 
> Show Applications in the nav if user has permissions for Advisor and/or Cost Management.
> 
> If user doesn't have permissions for either, (ideally we will be able to) hide the entire Applications section in the nav.
> 
> There are currently only two applications in this section: 
> 
> Advisor - allow access if user has advisor admin (star:star)  permissions
> 
> Cost - allow access if user has cost-management admin (star:star) permissions