### PR TITLE
chore: add dbz-ui

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -754,6 +754,10 @@ application-services:
       - id: cos
         title: "Connectors"
         group: overview
+        sub_apps:
+            - id: dbz
+              title: Debezium
+              group: overview
       - id: data-science
         title: "Data Science"
         group: overview
@@ -785,6 +789,10 @@ rhosak-control-plane-ui-build:
 cos-ui-build:
   title: UI for COS
   deployment_repo: https://github.com/RedHatInsights/cos-ui-build
+
+dbz-ui-build:
+  title: UI for Debezium
+  deployment_repo: https://github.com/RedHatInsights/dbz-ui-build
 
 sr-ui-build:
   title: UI for Service Registry

--- a/main.yml
+++ b/main.yml
@@ -754,10 +754,6 @@ application-services:
       - id: cos
         title: "Connectors"
         group: overview
-        sub_apps:
-            - id: dbz
-              title: Debezium
-              group: overview
       - id: data-science
         title: "Data Science"
         group: overview


### PR DESCRIPTION
We will deploy Debezium UI, and we will need the creation of a corresponding repo.
Debezium UI will be included as a federated module inside the COS UI. https://github.com/RedHatInsights/cloud-services-config/pull/612 will be the host app for this module.

can you assign this repo to @mdrillin @uidoyen and me