### PR TITLE
Add subscriptions->streams to application-services

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -68,6 +68,24 @@
             ]
         },
         {
+            "groupId": "insights",
+            "title": "Insights",
+            "navItems": [
+                {
+                    "title": "Subscriptions",
+                    "expandable": true,
+                    "routes": [
+                        {
+                            "appId": "applicationServices",
+                            "title": "Streams for Apache Kafka",
+                            "isBeta": true,
+                            "href": "/application-services/subscriptions/streams"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "appId": "applicationServices",
             "title": "Learning Resources",
             "href": "/application-services/learning-resources"

--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -69,6 +69,7 @@
         },
         {
             "groupId": "insights",
+            "icon": "trend-up",
             "title": "Insights",
             "navItems": [
                 {

--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -292,6 +292,13 @@
         "manifestLocation": "/apps/subscriptions/fed-mods.json",
         "modules": [
             {
+                "id": "application-services-subscriptions",
+                "module": "./RootApp",
+                "routes": [
+                    "/application-services/subscriptions"
+                ]
+            },
+            {
                 "id": "insights-subscriptions",
                 "module": "./RootApp",
                 "routes": [

--- a/main.yml
+++ b/main.yml
@@ -763,8 +763,12 @@ application-services:
       - id: service-registry
         title: "Service Registry"
         group: overview
-      - id: streams
-        group: overview
+      - id: subscriptions
+        title: Subscriptions
+        section: insights
+        sub_apps:
+          - id: streams
+            title: Streams for Apache Kafka
       - id: learning-resources
         title: "Learning Resources"
         group: overview

--- a/main.yml
+++ b/main.yml
@@ -763,12 +763,8 @@ application-services:
       - id: service-registry
         title: "Service Registry"
         group: overview
-      - id: subscriptions
-        title: Subscriptions
-        section: insights
-        sub_apps:
-          - id: streams
-            title: Streams for Apache Kafka
+      - id: streams
+        group: overview
       - id: learning-resources
         title: "Learning Resources"
         group: overview


### PR DESCRIPTION
I'm attempting to add a "Subscriptions" dropdown to Application Services.  It should Have a small Insights heading above it and one entry in the dropdown for "Streams for Apache Kafka".  The wireframe is [here](https://marvelapp.com/prototype/5dhc6c0/screen/82172335) for reference.  Let me know if this looks like it should generate what's in the wireframe.