### PR TITLE
Changed the order of links in Insights Advisor Menu according to task

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -39,14 +39,14 @@
                     "routes": [
                         {
                             "appId": "ocpAdvisor",
-                            "title": "Clusters",
-                            "href": "/openshift/insights/advisor/clusters",
+                            "title": "Recommendations",
+                            "href": "/openshift/insights/advisor/recommendations",
                             "product": "Red Hat OpenShift Cluster Manager"
                         },
                         {
                             "appId": "ocpAdvisor",
-                            "title": "Recommendations",
-                            "href": "/openshift/insights/advisor/recommendations",
+                            "title": "Clusters",
+                            "href": "/openshift/insights/advisor/clusters",
                             "product": "Red Hat OpenShift Cluster Manager"
                         }
                     ]


### PR DESCRIPTION
Because of the RHEL/Insights Advisor unification, I need to change places these 2 menus. 