### PR TITLE
Switched places recommendations and clusters link in the insights

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -39,14 +39,14 @@
                     "routes": [
                         {
                             "appId": "ocpAdvisor",
-                            "title": "Clusters",
-                            "href": "/openshift/insights/advisor/clusters",
+                            "title": "Recommendations",
+                            "href": "/openshift/insights/advisor/recommendations",
                             "product": "Red Hat OpenShift Cluster Manager"
                         },
                         {
                             "appId": "ocpAdvisor",
-                            "title": "Recommendations",
-                            "href": "/openshift/insights/advisor/recommendations",
+                            "title": "Clusters",
+                            "href": "/openshift/insights/advisor/clusters",
                             "product": "Red Hat OpenShift Cluster Manager"
                         }
                     ]


### PR DESCRIPTION
RHEL has a recommendations link in the first place in the menu, so we should keep the UX and UI the same.