### PR TITLE
image-builder: Drop permissions check

### DIFF
--- a/chrome/rhel-navigation.json
+++ b/chrome/rhel-navigation.json
@@ -60,18 +60,7 @@
                     "appId": "image_builder",
                     "title": "Image builder",
                     "href": "/insights/image-builder",
-                    "product": "Red Hat Insights",
-                    "permissions": [
-                        {
-                            "method": "apiRequest",
-                            "args": [
-                                {
-                                    "url": "/api/image-builder/v1/version",
-                                    "matcher": "isNotEmpty"
-                                }
-                            ]
-                        }
-                    ]
+                    "product": "Red Hat Insights"
                 },
                 {
                     "appId": "inventory",

--- a/main.yml
+++ b/main.yml
@@ -427,11 +427,6 @@ image-builder:
       - v1
     isBeta: true
   deployment_repo: https://github.com/RedHatInsights/image-builder-frontend-build
-  permissions:
-    method: apiRequest
-    args:
-      - url: '/api/image-builder/v1/version'
-        matcher: isNotEmpty
   frontend:
     section: operations
     module:


### PR DESCRIPTION
Image build has been public beta since last week. The check can be dropped now.