### PR TITLE
[prod-beta] Add subscriptions->streams to application-services

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -58,6 +58,25 @@
             ]
         },
         {
+            "groupId": "insights",
+            "icon": "trend-up",
+            "title": "Insights",
+            "navItems": [
+                {
+                    "title": "Subscriptions",
+                    "expandable": true,
+                    "routes": [
+                        {
+                            "appId": "applicationServices",
+                            "title": "Streams for Apache Kafka",
+                            "isBeta": true,
+                            "href": "/application-services/subscriptions/streams"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "appId": "dbaas",
             "title": "Database Access",
             "href": "/application-services/databases"

--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -268,6 +268,13 @@
         "manifestLocation": "/apps/subscriptions/fed-mods.json",
         "modules": [
             {
+                "id": "application-services-subscriptions",
+                "module": "./RootApp",
+                "routes": [
+                    "/application-services/subscriptions"
+                ]
+            },
+            {
                 "id": "insights-subscriptions",
                 "module": "./RootApp",
                 "routes": [


### PR DESCRIPTION
Related to #968 Activate subs for application services. This activates ONLY the Subscriptions (Watch) facet of Apps Services.

~Potentially blocked by #909 ?~ Appears 909 is editing a single menu item, shouldn't conflict
