### PR TITLE
[prod-stable] Add subscriptions->streams to application-services

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -57,6 +57,24 @@
             ]
         },
         {
+            "groupId": "insights",
+            "icon": "trend-up",
+            "title": "Insights",
+            "navItems": [
+                {
+                    "title": "Subscriptions",
+                    "expandable": true,
+                    "routes": [
+                        {
+                            "appId": "applicationServices",
+                            "title": "Streams for Apache Kafka",
+                            "href": "/application-services/subscriptions/streams"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "appId": "dbaas",
             "title": "Database Access",
             "href": "/application-services/databases"

--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -252,6 +252,13 @@
         "manifestLocation": "/apps/subscriptions/fed-mods.json",
         "modules": [
             {
+                "id": "application-services-subscriptions",
+                "module": "./RootApp",
+                "routes": [
+                    "/application-services/subscriptions"
+                ]
+            },
+            {
                 "id": "insights-subscriptions",
                 "module": "./RootApp",
                 "routes": [


### PR DESCRIPTION
Related to #968 Activate subs for application services. This activates ONLY the Subscriptions (Watch) facet of Apps Services.

~Potentially blocked by #909 ?~ Appears 909 is editing a single menu item, shouldn't conflict

Pending push date. Currently trending towards Dec 6th

@Hyperkid123 