### PR TITLE
fix: update service registry no-beta in qa-stable

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -30,7 +30,6 @@
                 {
                     "appId": "applicationServices",
                     "title": "Service Registry Instances",
-                    "isBeta": true,
                     "href": "/application-services/service-registry"
                 },
                 {


### PR DESCRIPTION
FYI @pmuir 

Updates navigation bar in qa-stable env, to not display Service Registry as beta