### PR TITLE
fix: update service registry no-beta in prod-stable

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -30,7 +30,6 @@
                 {
                     "appId": "applicationServices",
                     "title": "Service Registry Instances",
-                    "isBeta": true,
                     "href": "/application-services/service-registry"
                 },
                 {


### PR DESCRIPTION
Do not merge until #985 is merged and we are ready

Updates navigation in production env to no longer display Service Registry as beta