### PR TITLE
[ci-stable] Enable chrome 2 from ansible hub.

### DIFF
--- a/chrome/ansible-navigation.json
+++ b/chrome/ansible-navigation.json
@@ -13,25 +13,25 @@
             "expandable": true,
             "routes": [
                 {
-                    "appId": "ansibleAutomationHub",
+                    "appId": "automationHub",
                     "title": "Collections",
                     "href": "/ansible/automation-hub/",
                     "product": "Ansible Automation Hub"
                 },
                 {
-                    "appId": "ansibleAutomationHub",
+                    "appId": "automationHub",
                     "title": "Partners",
                     "href": "/ansible/automation-hub/partners",
                     "product": "Ansible Automation Hub"
                 },
                 {
-                    "appId": "ansibleAutomationHub",
+                    "appId": "automationHub",
                     "title": "Repo Management",
                     "href": "/ansible/automation-hub/repositories",
                     "product": "Ansible Automation Hub"
                 },
                 {
-                    "appId": "ansibleAutomationHub",
+                    "appId": "automationHub",
                     "title": "Connect to Hub",
                     "href": "/ansible/automation-hub/token",
                     "product": "Ansible Automation Hub"

--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -359,12 +359,12 @@
             }
         ]
     },
-    "ansibleAutomationHub": {
-        "dynamic": false,
+    "automationHub": {
+        "manifestLocation": "/apps/automation-hub/fed-mods.json",
         "modules": [
             {
                 "id": "ansible-automation-hub",
-                "dynamic": false,
+                "module": "./RootApp",
                 "routes": [
                     "/ansible/automation-hub"
                 ]


### PR DESCRIPTION
required by: https://github.com/ansible/ansible-hub-ui/pull/920 