### PR TITLE
[stage-stable] Automation Hub - drop My namespaces

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -212,8 +212,6 @@ automation-hub:
         default: true
       - id: partners
         title: Partners
-      - id: my-namespaces
-        title: My namespaces
       - id: repositories
         title: Repo Management
       - id: token


### PR DESCRIPTION
Follow-up to #769 (prod-beta) & #770 (prod-stable)

Removing Automation Hub > My namespaces from stage-stable

Cc @ZitaNemeckova , @Hyperkid123 