### PR TITLE
[nightly-beta] Automation Hub - drop My namespaces

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -161,8 +161,6 @@ automation-hub:
         default: true
       - id: partners
         title: Partners
-      - id: my-namespaces
-        title: My namespaces
       - id: repositories
         title: Repo Management
       - id: token


### PR DESCRIPTION
Follow-up to #769 (prod-beta) & #770 (prod-stable)

Removing Automation Hub > My namespaces from nightly-beta

Cc @ZitaNemeckova , @Hyperkid123 