### PR TITLE
[qa-stable] Automation Hub - drop My namespaces (#994)

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -212,8 +212,6 @@ automation-hub:
         default: true
       - id: partners
         title: Partners
-      - id: my-namespaces
-        title: My namespaces
       - id: repositories
         title: Repo Management
       - id: token


### PR DESCRIPTION
Problem:

https://console.stage.redhat.com/ansible/automation-hub still shows "My Namespaces" in left-side nav.

My original assumption was that stage-stable (#994) is the place to fix it, but.. maybe not?

`qa-stable` is the only branch with `My namespaces` now, so my guess is that either stage is deployed from qa-stable for some reason, or that something failed after merging #994 

@Hyperkid123 can you check please? :)