### PR TITLE
Remove my namespaces from navigation config

### DIFF
--- a/chrome/ansible-navigation.json
+++ b/chrome/ansible-navigation.json
@@ -26,12 +26,6 @@
                 },
                 {
                     "appId": "ansibleAutomationHub",
-                    "title": "My Namespaces",
-                    "href": "/ansible/automation-hub/my-namespaces",
-                    "product": "Ansible Automation Hub"
-                },
-                {
-                    "appId": "ansibleAutomationHub",
                     "title": "Repo Management",
                     "href": "/ansible/automation-hub/repositories",
                     "product": "Ansible Automation Hub"


### PR DESCRIPTION
### No need for my namespaces in navigation for ansible

Since we no longer need my namespaces in navigation, let's remove them.

ping @himdel 