### PR TITLE
ROS api routes getting upgraded from v0 to v1

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -735,7 +735,7 @@ ros:
   title: Resource Optimization
   api:
     versions:
-      - v0
+      - v1
   channel: '#team-ros'
   deployment_repo: https://github.com/RedHatInsights/ros-frontend-build
   frontend:


### PR DESCRIPTION
We are planning for GA very soon, our API endpoints are now v1.

References:
For preprod envs: https://github.com/RedHatInsights/cloud-services-config/pull/1000/files
JIRA: https://issues.redhat.com/browse/RHIROS-426