### PR TITLE
update ROS API endpoint to v1 for qa-stable

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -715,7 +715,7 @@ ros:
   title: Resource Optimization
   api:
     versions:
-      - v0
+      - v1
   channel: '#team-ros'
   deployment_repo: https://github.com/RedHatInsights/ros-frontend-build
   frontend:


### PR DESCRIPTION
Updated ROS API endpoint to V1 for qa-stable envrionment as we moved from V0 to V1