### PR TITLE
Enable defaultDocumentTitle module config.

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -1,6 +1,7 @@
 {
     "landing": {
         "manifestLocation": "/apps/landing/fed-mods.json",
+        "defaultDocumentTitle": "Home",
         "modules": [
             {
                 "id": "landing",

--- a/chrome/validationSchemas/modules.js
+++ b/chrome/validationSchemas/modules.js
@@ -34,6 +34,7 @@ const routeModuleSchema = Joi.object({
 
 const moduleItemSchema = Joi.object({
   dynamic: Joi.boolean().optional(),
+  defaultDocumentTitle: Joi.string().optional(),
   manifestLocation: Joi.alternatives().conditional('dynamic', {
     is: false,
     then: Joi.any().forbidden(),


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-17548

Enables configuring browser document title via CSC. This is required for migration to a single HTML template. The validator change has to be propagated to all environments.