### PR TITLE
[prod-stable] Enable OCP Advisor and add navigation entry

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -164,6 +164,18 @@
             }
         ]
     },
+    "ocpAdvisor": {
+        "manifestLocation": "/apps/ocp-advisor/fed-mods.json",
+        "modules": [
+            {
+                "id": "ocp-advisor",
+                "module": "./RootApp",
+                "routes": [
+                    "/openshift/insights/advisor"
+                ]
+            }
+        ]
+    },
     "drift": {
         "manifestLocation": "/apps/drift/fed-mods.json",
         "modules": [

--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -34,6 +34,24 @@
             "title": "Insights",
             "navItems": [
                 {
+                    "title": "Advisor",
+                    "expandable": true,
+                    "routes": [
+                        {
+                            "appId": "ocpAdvisor",
+                            "title": "Recommendations",
+                            "href": "/openshift/insights/advisor/recommendations",
+                            "product": "Red Hat OpenShift Cluster Manager"
+                        },
+                        {
+                            "appId": "ocpAdvisor",
+                            "title": "Clusters",
+                            "href": "/openshift/insights/advisor/clusters",
+                            "product": "Red Hat OpenShift Cluster Manager"
+                        }
+                    ]
+                },
+                {
                     "title": "Subscriptions",
                     "expandable": true,
                     "filterable": true,

--- a/main.yml
+++ b/main.yml
@@ -556,6 +556,8 @@ openshift:
       - id: downloads
         title: Downloads
         group: openshift
+      - id: ocp-advisor
+        group: insights
       - id: subscriptions
         title: Subscriptions
         section: insights
@@ -577,6 +579,22 @@ openshift:
         section: insights
 
   top_level: true
+
+ocp-advisor: 
+  title: Advisor
+  source_repo: https://github.com/RedHatInsights/ocp-advisor-frontend
+  deployment_repo: https://github.com/RedHatInsights/ocp-advisor-frontend-build
+  frontend:
+    module: ocp-advisor#./RootApp
+    paths:
+      - /openshift/insights/advisor
+    sub_apps:
+      - id: clusters
+        title: Clusters
+        reload: clusters 
+      - id: recommendations
+        title: Recommendations
+        reload: recommendations
 
 patch:
   title: Patch


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/CCXDEV-7329.

This enables OCP Advisor application (OpenShift Insights) under the production stable environment. The patch also updates the navigation menu with the corresponding new entry.