### PR TITLE
[qa-stable] Enable OCP Advisor and add navigation entry

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -190,6 +190,18 @@
             }
         ]
     },
+    "ocpAdvisor": {
+        "manifestLocation": "/apps/ocp-advisor/fed-mods.json",
+        "modules": [
+            {
+                "id": "ocp-advisor",
+                "module": "./RootApp",
+                "routes": [
+                    "/openshift/insights/advisor"
+                ]
+            }
+        ]
+    },
     "drift": {
         "manifestLocation": "/apps/drift/fed-mods.json",
         "modules": [

--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -34,6 +34,24 @@
             "title": "Insights",
             "navItems": [
                 {
+                    "title": "Advisor",
+                    "expandable": true,
+                    "routes": [
+                        {
+                            "appId": "ocpAdvisor",
+                            "title": "Recommendations",
+                            "href": "/openshift/insights/advisor/recommendations",
+                            "product": "Red Hat OpenShift Cluster Manager"
+                        },
+                        {
+                            "appId": "ocpAdvisor",
+                            "title": "Clusters",
+                            "href": "/openshift/insights/advisor/clusters",
+                            "product": "Red Hat OpenShift Cluster Manager"
+                        }
+                    ]
+                },
+                {
                     "title": "Subscriptions",
                     "expandable": true,
                     "routes": [

--- a/main.yml
+++ b/main.yml
@@ -592,6 +592,8 @@ openshift:
       - id: downloads
         title: Downloads
         group: openshift
+      - id: ocp-advisor
+        group: insights
       - id: subscriptions
         title: Subscriptions
         section: insights
@@ -612,6 +614,22 @@ openshift:
       - id: cost-management
 
   top_level: true
+
+ocp-advisor: 
+  title: Advisor
+  source_repo: https://github.com/RedHatInsights/ocp-advisor-frontend
+  deployment_repo: https://github.com/RedHatInsights/ocp-advisor-frontend-build
+  frontend:
+    module: ocp-advisor#./RootApp
+    paths:
+      - /openshift/insights/advisor
+    sub_apps:
+      - id: clusters
+        title: Clusters
+        reload: clusters 
+      - id: recommendations
+        title: Recommendations
+        reload: recommendations
 
 patch:
   title: Patch


### PR DESCRIPTION
This enables OCP Advisor application (OpenShift Insights) under the qa stable environment. The patch also updates the navigation menu with the corresponding new entry.