### PR TITLE
chore: add se-ui

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -51,6 +51,11 @@
             ]
         },
         {
+            "appId": "applicationServices",
+            "title": "Smart Events",
+            "href": "/application-services/smart-events"
+        },
+        {
             "title": "Streams for Apache Kafka",
             "expandable": true,
             "routes": [

--- a/main.yml
+++ b/main.yml
@@ -783,6 +783,9 @@ application-services:
       - id: service-registry
         title: "Service Registry"
         group: overview
+      - id: smart-events
+        title: "Smart Events"
+        group: overview
       - id: streams
         group: overview
       - id: learning-resources
@@ -817,6 +820,10 @@ sr-ui-build:
 srs-ui-build:
   title: UI for Service Registry Control Plane
   deployment_repo: https://github.com/RedHatInsights/srs-ui-build
+
+se-ui-build:
+  title: UI for Smart Events
+  deployment_repo: https://github.com/RedHatInsights/se-ui-build
 
 rhoas-guides-build:
   title: Guides for RHOAS


### PR DESCRIPTION
Opening this PR for the Smart Events application. We need the creation of a corresponding `se-ui-build` repo.
The UI will be a federated module loaded inside Application Services (like cos, kas and others).

Could you please add as admin also @manstis and @vpellegrino?