### PR TITLE
Remove is_beta from apps that are available in prod

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -240,7 +240,6 @@ compliance:
   api:
     versions:
       - v1
-    isBeta: true
   deployment_repo: https://github.com/RedHatInsights/compliance-frontend-build
   frontend:
     section: security
@@ -268,7 +267,6 @@ cost-management:
   api:
     versions:
       - v1
-    isBeta: true
   channel: '#koku'
   deployment_repo: https://github.com/RedHatInsights/cost-management-build
   productId: Red Hat Cost Management
@@ -762,7 +760,6 @@ sources:
   api:
     versions:
       - v1
-    isBeta: true
   channel: '#sources'
   deployment_repo: https://github.com/RedHatInsights/sources-ui-deploy
   frontend:


### PR DESCRIPTION
these apps in prod-stable do not have the `is_beta` flag, but they do in stage. This should help out the security folks 😄