### PR TITLE
Add image-builder federated module

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -512,5 +512,17 @@
                 ]
             }
         ]
+    },
+    "image_builder": {
+        "manifestLocation": "/apps/image-builder/fed-mods.json",
+        "modules": [
+            {
+                "id": "image-builder",
+                "module": "./RootApp",
+                "routes": [
+                    "/insights/image-builder"
+                ]
+            }
+        ]
     }
 }


### PR DESCRIPTION
Oversight from https://github.com/RedHatInsights/cloud-services-config/pull/1100, as I think this is strictly required? 

Also noticed we dont' follow the `-` => camelcase convention, but I think we'll need to duplicate our own federated module config for that and expose it both as image_builder and imageBuilder. 