### PR TITLE
Fix API docs for sources

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -1012,7 +1012,7 @@ sources:
   title: Discovered Inventory
   api:
     versions:
-      - v1
+      - v3.1
     isBeta: true
   channel: '#sources'
   deployment_repo: https://github.com/RedHatInsights/sources-ui-deploy

--- a/main.yml
+++ b/main.yml
@@ -1013,7 +1013,6 @@ sources:
   api:
     versions:
       - v3.1
-    isBeta: true
   channel: '#sources'
   deployment_repo: https://github.com/RedHatInsights/sources-ui-deploy
   frontend:


### PR DESCRIPTION
This change adds open api docs for sources to this page https://console.stage.redhat.com/docs/api .

Our openapi specs is here https://console.stage.redhat.com/api/sources/v3.1/openapi.json 

Thanks @Hyperkid123! 