### PR TITLE
Fix api docs sources

### DIFF
--- a/chrome/ansible-navigation.json
+++ b/chrome/ansible-navigation.json
@@ -39,62 +39,6 @@
             ]
         },
         {
-            "title": "Automation Services Catalog",
-            "expandable": true,
-            "routes": [
-                {
-                    "appId": "catalog",
-                    "title": "Products",
-                    "href": "/ansible/catalog/products"
-                },
-                {
-                    "appId": "catalog",
-                    "title": "Portfolios",
-                    "href": "/ansible/catalog/portfolios"
-                },
-                {
-                    "appId": "catalog",
-                    "title": "Platforms",
-                    "href": "/ansible/catalog/platforms",
-                    "permissions": [
-                        {
-                            "method": "hasPermissions",
-                            "args": [
-                                [
-                                    "catalog:portfolios:create"
-                                ]
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "appId": "catalog",
-                    "title": "order-processes",
-                    "href": "/ansible/catalog/order-processes",
-                    "permissions": [
-                        {
-                            "method": "hasPermissions",
-                            "args": [
-                                [
-                                    "catalog:order_processes:read"
-                                ]
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "appId": "catalog",
-                    "title": "Orders",
-                    "href": "/ansible/catalog/orders"
-                },
-                {
-                    "appId": "approval",
-                    "title": "Approval",
-                    "href": "/ansible/catalog/approval"
-                }
-            ]
-        },
-        {
             "groupId": "operations",
             "icon": "wrench",
             "title": "Operations Insights",
@@ -231,7 +175,7 @@
                     "appId": "tasks",
                     "title": "Tasks",
                     "href": "/ansible/tasks",
-                    "product": "Red Hat Insights"                    
+                    "product": "Red Hat Insights"
                 }
             ]
         },

--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -30,13 +30,11 @@
             {
               "appId": "applicationServices",
               "title": "Overview",
-              "isBeta": true,
               "href": "/application-services/streams/overview"
             },
             {
               "appId": "applicationServices",
               "title": "Kafka Instances",
-              "isBeta": true,
               "href": "/application-services/streams"
             },
             {

--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -102,6 +102,23 @@
       ]
     },
     {
+      "title": "Advanced Cluster Security",
+      "expandable": true,
+      "routes": [
+          {
+              "appId": "applicationServices",
+              "title": "ACS Instances",
+              "isBeta": true,
+              "href": "/application-services/acs"
+          },
+          {
+              "title": "Documentation",
+              "isExternal": true,
+              "href": "https://docs.openshift.com/acs/3.66/welcome/index.html"
+          }
+      ]
+    },
+    {
       "groupId": "insights",
       "icon": "trend-up",
       "title": "Red Hat Insights",
@@ -113,7 +130,6 @@
             {
               "appId": "applicationServices",
               "title": "Streams for Apache Kafka",
-              "isBeta": true,
               "href": "/application-services/subscriptions/streams"
             }
           ]

--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -425,30 +425,6 @@
             }
         ]
     },
-    "approval": {
-        "manifestLocation": "/apps/approval/fed-mods.json",
-        "modules": [
-            {
-                "id": "approval",
-                "module": "./RootApp",
-                "routes": [
-                    "/ansible/catalog/approval"
-                ]
-            }
-        ]
-    },
-    "catalog": {
-        "manifestLocation": "/apps/catalog/fed-mods.json",
-        "modules": [
-            {
-                "id": "catalog",
-                "module": "./RootApp",
-                "routes": [
-                    "/ansible/catalog"
-                ]
-            }
-        ]
-    },
     "automationHub": {
         "manifestLocation": "/apps/automation-hub/fed-mods.json",
         "modules": [

--- a/main.yml
+++ b/main.yml
@@ -961,8 +961,7 @@ sources:
   title: Discovered Inventory
   api:
     versions:
-      - v1
-    isBeta: true
+      - v3.1
   channel: '#sources'
   deployment_repo: https://github.com/RedHatInsights/sources-ui-deploy
   frontend:

--- a/main.yml
+++ b/main.yml
@@ -790,7 +790,6 @@ patch:
   api:
     versions:
       - v1
-    isBeta: true
   channel: '#team-patchman'
   deployment_repo: https://github.com/RedHatInsights/patchman-ui-build
   frontend:

--- a/main.yml
+++ b/main.yml
@@ -68,7 +68,6 @@ ansible:
         default: true
         group: ansible-dashboard
       - id: automation-hub
-      - id: catalog
       - id: automation-analytics
   top_level: true
 
@@ -111,22 +110,6 @@ applications:
     paths:
       - /settings/applications
   source_repo: https://github.com/RedHatInsights/settings-frontend
-
-approval:
-  title: Approval
-  api:
-    versions:
-      - v1
-  deployment_repo: https://github.com/RedHatInsights/approvals-frontend-deploy.git
-  frontend:
-    module:
-      appName: approval
-      scope: approval
-      module: ./RootApp
-    paths:
-      - /ansible/catalog/approval
-    reload: catalog/approval
-  source_repo: https://github.com/RedHatInsights/approval-ui
 
 automation-analytics:
   title: Automation Analytics
@@ -177,39 +160,6 @@ automation-hub:
       - id: token
         title: Connect to Hub
   source_repo: https://github.com/ansible/ansible-hub-ui
-
-catalog:
-  title: Automation Services Catalog
-  api:
-    versions:
-      - v1
-  channel: '#insights-catalog'
-  deployment_repo: https://github.com/RedHatInsights/catalog-static-deploy
-  frontend:
-    paths:
-      - /ansible/catalog
-    sub_apps:
-      - id: products
-        title: Products
-      - id: portfolios
-        title: Portfolios
-        default: true
-      - id: platforms
-        title: Platforms
-        permissions:
-          method: hasPermissions
-          args:
-            - [catalog:portfolios:create]
-      - id: order-processes
-        title: Order processes
-        permissions:
-          method: hasPermissions
-          args:
-            - [catalog:order_processes:read]
-      - id: orders
-        title: Orders
-      - id: approval
-  source_repo: https://github.com/RedHatInsights/catalog-ui
 
 ccx:
   title: OpenShift Insights
@@ -683,7 +633,7 @@ openshift:
 
   top_level: true
 
-ocp-advisor: 
+ocp-advisor:
   title: Advisor
   source_repo: https://github.com/RedHatInsights/ocp-advisor-frontend
   deployment_repo: https://github.com/RedHatInsights/ocp-advisor-frontend-build
@@ -694,12 +644,12 @@ ocp-advisor:
     sub_apps:
       - id: clusters
         title: Clusters
-        reload: clusters 
+        reload: clusters
       - id: recommendations
         title: Recommendations
         reload: recommendations
 
-ocp-vulnerability: 
+ocp-vulnerability:
   title: Vulnerability
   channel: '#forum-ccx-vulnerability'
   source_repo: https://github.com/RedHatInsights/vuln4shift-frontend
@@ -711,7 +661,7 @@ ocp-vulnerability:
     sub_apps:
       - id: cves
         title: CVEs
-        reload: cves 
+        reload: cves
       - id: clusters
         title: Clusters
         reload: clusters
@@ -772,7 +722,7 @@ application-services:
         group: overview
       - id: learning-resources
         title: "Learning Resources"
-        group: overview  
+        group: overview
       - id: api-management
         title: "API Management"
         group: overview


### PR DESCRIPTION
Related to: https://github.com/RedHatInsights/cloud-services-config/pull/1137

This change adds open api docs for sources to this page https://console.stage.redhat.com/docs/api

Our openapi specs is here https://console.stage.redhat.com/api/sources/v3.1/openapi.json