### PR TITLE
fix: change title for sources for ci-stable

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -958,7 +958,7 @@ settings:
         navigate: https://access.redhat.com/documentation/en-us/red_hat_hybrid_cloud_console
 
 sources:
-  title: Discovered Inventory
+  title: Sources
   api:
     versions:
       - v1


### PR DESCRIPTION
Related to: https://github.com/RedHatInsights/cloud-services-config/pull/1140

The topological inventory no longer exists, and we are currently known only as "sources".