### PR TITLE
Fix API docs for sources in CI-Stable

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -961,8 +961,7 @@ sources:
   title: Discovered Inventory
   api:
     versions:
-      - v1
-    isBeta: true
+      - v3.1
   channel: '#sources'
   deployment_repo: https://github.com/RedHatInsights/sources-ui-deploy
   frontend:


### PR DESCRIPTION
Related to: https://github.com/RedHatInsights/cloud-services-config/pull/1137

This change adds open api docs for sources to this page https://console.stage.redhat.com/docs/api

Our openapi specs is here https://console.stage.redhat.com/api/sources/v3.1/openapi.json