### PR TITLE
Fix IO Gathering Conditions Service apiName

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -219,7 +219,7 @@ ccx:
         title: Insights Results Aggregator
         versions:
           - v1
-      insights-operator-gathering-conditions-service:
+      gathering:
         title: Insights Operator Gathering Conditions Service
         versions:
           - v1


### PR DESCRIPTION
Fix the IO gathering conditions service apiName to match this PR - https://github.com/RedHatInsights/insights-operator-gathering-conditions-service/pull/150.

Using [api/gathering](https://console.stage.redhat.com/beta/docs/api/gathering) instead of [api/insights-operator-gathering-conditions-service](https://console.stage.redhat.com/beta/docs/api/insights-operator-gathering-conditions-service).