### PR TITLE
[qa-beta] Rename Insights to Red Hat Insights in openshift-navigation

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -37,7 +37,7 @@
         },
         {
             "groupId": "insights",
-            "title": "Insights",
+            "title": "Red Hat Insights",
             "navItems": [
                 {
                     "title": "Advisor",


### PR DESCRIPTION
There is a UX request to rename the navigation items group "Insights" to "Red Hat Insights"

Fixes https://issues.redhat.com/browse/CCXDEV-8047.
