### PR TITLE
Add trend-up icon to openshift - insights navigation group

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -32,6 +32,7 @@
         {
             "groupId": "insights",
             "title": "Red Hat Insights",
+            "icon": "trend-up",
             "navItems": [
                 {
                     "title": "Advisor",


### PR DESCRIPTION
This adds the icon "trend-up" to the Red Hat Insights navigation group for the Openshift bundle.
![image](https://user-images.githubusercontent.com/31385370/166688056-146696fc-beca-4b1e-a14b-80dacd3c7103.png)
