### PR TITLE
[CCXDEV-8023] Add v2 version to the aggregator

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -219,6 +219,7 @@ ccx:
         title: Insights Results Aggregator
         versions:
           - v1
+          - v2
       gathering:
         title: Insights Operator Gathering Conditions Service
         versions:


### PR DESCRIPTION
We have a second version of the API at https://console.redhat.com/api/insights-results-aggregator/v2/openapi.json. Let's start showing it too.