### PR TITLE
Added API Designer builds to main.yml

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -837,6 +837,14 @@ srs-ui-build:
   title: UI for Service Registry Control Plane
   deployment_repo: https://github.com/RedHatInsights/srs-ui-build
 
+ads-ui-build:
+  title: UI for API Designer
+  deployment_repo: https://github.com/RedHatInsights/ads-ui-build
+
+ads-editors-build:
+  title: UI for API Designer (Editor Components)
+  deployment_repo: https://github.com/RedHatInsights/ads-editors-build
+
 se-ui-build:
   title: UI for Smart Events
   deployment_repo: https://github.com/RedHatInsights/se-ui-build


### PR DESCRIPTION
We are creating a new managed application service called API Designer and we need it to be available in qaprodauth for testing purposes.  Phase 1 of API Designer is UI-only (no back-end) but is made up of two UI applications.  This PR adds these two new apps to the list found in `main.yml`.