### PR TITLE
Adding the API Designer navigation item

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -19,6 +19,22 @@
       "icon": "cloud",
       "navItems": [
         {
+          "title": "API Designer",
+          "expandable": true,
+          "routes": [
+            {
+              "appId": "applicationServices",
+              "title": "API and Schema Designs",
+              "href": "/application-services/api-designer"
+            },
+            {
+              "title": "Documentation",
+              "isExternal": true,
+              "href": "https://access.redhat.com/documentation/en-us/red_hat_openshift_api_designer"
+            }
+          ]
+        },
+        {
           "appId": "applicationServices",
           "title": "API Management",
           "href": "/application-services/api-management"


### PR DESCRIPTION
We are adding a new application services managed service called API Designer.  We need a navigation menu on the left for it.  Here is the JIRA with approvals:

https://issues.redhat.com/browse/RHCLOUD-19795

I think we may still be working on exactly what the terminology will be for the sub-menu item.  I've take a stab at it for now and we can change it if needed (currently I've made it `API and Schema Designs` to try and fit in with the existing pattern as best I can).