### PR TITLE
[RHCLOUD-19946] Update API version for Sources in PROD-BETA

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -887,8 +887,7 @@ sources:
   title: Discovered Inventory
   api:
     versions:
-      - v1
-    isBeta: true
+      - v3.1
   channel: '#sources'
   deployment_repo: https://github.com/RedHatInsights/sources-ui-deploy
   frontend:


### PR DESCRIPTION
Related to: https://github.com/RedHatInsights/cloud-services-config/pull/1137

This change adds open api docs for sources to this page https://console.redhat.com/beta/docs/api/sources

Our openapi specs is here https://console.redhat.com/api/sources/v3.1/openapi.json

JIRA: [RHCLOUD-19946](https://issues.redhat.com/browse/RHCLOUD-19946)