### PR TITLE
feat: adding acs to prod-beta

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -102,6 +102,23 @@
       ]
     },
     {
+      "title": "Advanced Cluster Security",
+      "expandable": true,
+      "routes": [
+        {
+          "appId": "applicationServices",
+          "title": "ACS Instances",
+          "isBeta": true,
+          "href": "/application-services/acs"
+        },
+        {
+          "title": "Documentation",
+          "isExternal": true,
+          "href": "https://docs.openshift.com/acs/3.66/welcome/index.html"
+        }
+      ]
+    },
+    {
       "groupId": "insights",
       "icon": "trend-up",
       "title": "Red Hat Insights",

--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -574,5 +574,17 @@
                 ]
             }
       ]
-    }
+    },
+    "acs": {
+        "manifestLocation": "/apps/acs/fed-mods.json",
+        "modules": [
+          {
+              "id": "acs",
+              "module": "./RootApp",
+              "routes": [
+                  "/application-services/acs"
+              ]
+          }
+      ]
+    },
 }

--- a/main.yml
+++ b/main.yml
@@ -14,6 +14,18 @@ access-requests:
     paths:
       - /internal/access-requests
 
+acs:
+  title: Advanced Cluster Security
+  api:
+    versions:
+      - v1
+  description: Frontend for Red Hat employees to manage ACS instances
+  deployment_repo: https://github.com/RedHatInsights/acs-ui-build
+  frontend:
+    paths:
+      - /application-services/acs
+  source_repo: https://github.com/RedHatInsights/acs-ui
+
 advisor:
   title: Advisor
   api:


### PR DESCRIPTION
This PR is to add the Advanced Cluster Security (ACS) app to the consoledot (`prod-beta`) environment