### PR TITLE
Adding the API Designer navigation item (ci-stable)

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -19,6 +19,22 @@
       "icon": "cloud",
       "navItems": [
         {
+          "title": "API Designer",
+          "expandable": true,
+          "routes": [
+            {
+              "appId": "applicationServices",
+              "title": "API and Schema Designs",
+              "href": "/application-services/api-designer"
+            },
+            {
+              "title": "Documentation",
+              "isExternal": true,
+              "href": "https://access.redhat.com/documentation/en-us/red_hat_openshift_api_designer"
+            }
+          ]
+        },
+        {
           "appId": "applicationServices",
           "title": "API Management",
           "href": "/application-services/api-management"


### PR DESCRIPTION
This change already exists in `ci-beta`, this PR promotes the API Designer navigation link to `ci-stable`.