### PR TITLE
rename patch navigation "Patch set"

### DIFF
--- a/chrome/rhel-navigation.json
+++ b/chrome/rhel-navigation.json
@@ -68,8 +68,8 @@
               },
               {
                 "appId": "patch",
-                "title": "Patch set",
-                "href": "/insights/patch/patch-set",
+                "title": "Templates",
+                "href": "/insights/patch/templates",
                 "product": "Red Hat Insights"
               }
             ]


### PR DESCRIPTION
UX requested to rename 'Patch set' nav to 'Templates'