### PR TITLE
chore: add apis configuration

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -745,8 +745,6 @@ onboarding:
 
 streams:
   title: "Streams for Apache Kafka"
-  api:
-    url: https://api.openshift.com/api/kafkas_mgmt/v1/openapi
   frontend:
     sub_apps:
       - id: kafkas
@@ -765,6 +763,59 @@ service-registry:
       - id: streams-docs
         title: Documentation
         navigate: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_registry
+
+
+## Managed Services APIs
+
+kafkamgmt:
+  title: "OpenShift Streams for Apache Kafka Management API"
+  api:
+    owner: redhat-developer
+    repo: app-services-sdk-core
+    path: kas-fleet-manager.yaml?ref=doc-portal
+
+connectormgmt:
+  title: "OpenShift Connectors Management API "
+  api:
+    owner: redhat-developer
+    repo: app-services-sdk-core
+    path: connector_mgmt?ref=doc-portal
+
+serviceregistrymgmt:
+  title: "OpenShift Service Registry Management API"
+  api:
+    owner: redhat-developer
+    repo: app-services-sdk-core
+    path: srs-fleet-manager.json?ref=doc-portal
+  
+smarteventsmgmt:
+  title: "Smart Events Management API"
+  api:
+    owner: redhat-developer
+    repo: app-services-sdk-core
+    path: smartevents-mgmt.yaml?ref=doc-portal
+
+serviceaccountsmgmt:
+  title: "Service Accounts Management API"
+  api:
+    owner: redhat-developer
+    repo: app-services-sdk-core
+    path: service-accounts.yaml?ref=doc-portal
+
+kafkainstance:
+  title: "OpenShift Streams for Apache Kafka Instance API"
+  api:
+    owner: redhat-developer
+    repo: app-services-sdk-core
+    path: kafka-admin-rest.yaml?ref=doc-portal
+
+registryinstance:
+  title: "OpenShift Service Registry Instance API"
+  api:
+    owner: redhat-developer
+    repo: app-services-sdk-core
+    path: registry-instance.json?ref=doc-portal
+
 
 application-services:
   title: Application Services

--- a/main.yml
+++ b/main.yml
@@ -765,56 +765,53 @@ service-registry:
         navigate: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_registry
 
 
-## Managed Services APIs
-
-kafkamgmt:
-  title: "OpenShift Streams for Apache Kafka Management API"
+## App Services (RHOAS) APIs
+app-services-apis:
+  title: Application Services
   api:
-    owner: redhat-developer
-    repo: app-services-sdk-core
-    path: kas-fleet-manager.yaml?ref=doc-portal
-
-connectormgmt:
-  title: "OpenShift Connectors Management API "
-  api:
-    owner: redhat-developer
-    repo: app-services-sdk-core
-    path: connector_mgmt?ref=doc-portal
-
-serviceregistrymgmt:
-  title: "OpenShift Service Registry Management API"
-  api:
-    owner: redhat-developer
-    repo: app-services-sdk-core
-    path: srs-fleet-manager.json?ref=doc-portal
-  
-smarteventsmgmt:
-  title: "Smart Events Management API"
-  api:
-    owner: redhat-developer
-    repo: app-services-sdk-core
-    path: smartevents-mgmt.yaml?ref=doc-portal
-
-serviceaccountsmgmt:
-  title: "Service Accounts Management API"
-  api:
-    owner: redhat-developer
-    repo: app-services-sdk-core
-    path: service-accounts.yaml?ref=doc-portal
-
-kafkainstance:
-  title: "OpenShift Streams for Apache Kafka Instance API"
-  api:
-    owner: redhat-developer
-    repo: app-services-sdk-core
-    path: kafka-admin-rest.yaml?ref=doc-portal
-
-registryinstance:
-  title: "OpenShift Service Registry Instance API"
-  api:
-    owner: redhat-developer
-    repo: app-services-sdk-core
-    path: registry-instance.json?ref=doc-portal
+    subItems:
+      kafkamgmt:
+        title: "OpenShift Streams for Apache Kafka Management API"
+        api:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: kas-fleet-manager.yaml?ref=doc-portal
+      connectormgmt:
+        title: "OpenShift Connectors Management API "
+        api:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: connector_mgmt?ref=doc-portal
+      serviceregistrymgmt:
+        title: "OpenShift Service Registry Management API"
+        api:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: srs-fleet-manager.json?ref=doc-portal
+      smarteventsmgmt:
+        title: "Smart Events Management API"
+        api:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: smartevents-mgmt.yaml?ref=doc-portal
+      serviceaccountsmgmt:
+        title: "Service Accounts Management API"
+        api:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: service-accounts.yaml?ref=doc-portal
+      kafkainstance:
+        title: "OpenShift Streams for Apache Kafka Instance API"
+        api:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: kafka-admin-rest.yaml?ref=doc-portal
+      registryinstance:
+        title: "OpenShift Service Registry Instance API"
+        api:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: registry-instance.json?ref=doc-portal
 
 
 application-services:

--- a/main.yml
+++ b/main.yml
@@ -764,7 +764,6 @@ service-registry:
         title: Documentation
         navigate: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_registry
 
-
 ## App Services (RHOAS) APIs
 app-services-apis:
   title: Application Services
@@ -772,58 +771,48 @@ app-services-apis:
     subItems:
       kafkamgmt:
         title: "OpenShift Streams for Apache Kafka Management API"
-        api:
-          github:
-            owner: redhat-developer
-            repo: app-services-sdk-core
-            path: kas-fleet-manager.yaml?ref=doc-portal
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: kas-fleet-manager.yaml?ref=doc-portal
       connectormgmt:
         title: "OpenShift Connectors Management API "
-        api:
-          github:
-            owner: redhat-developer
-            repo: app-services-sdk-core
-            path: connector_mgmt?ref=doc-portal
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: connector_mgmt?ref=doc-portal
       serviceregistrymgmt:
         title: "OpenShift Service Registry Management API"
-        api:
-          github:
-            owner: redhat-developer
-            repo: app-services-sdk-core
-            path: srs-fleet-manager.json?ref=doc-portal
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: srs-fleet-manager.json?ref=doc-portal
       smarteventsmgmt:
         title: "Smart Events Management API"
-        api:
-          github:
-            owner: redhat-developer
-            repo: app-services-sdk-core
-            path: smartevents-mgmt.yaml?ref=doc-portal
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: smartevents-mgmt.yaml?ref=doc-portal
       serviceaccountsmgmt:
         title: "Service Accounts Management API"
-        api:
-          github:
-            owner: redhat-developer
-            repo: app-services-sdk-core
-            path: service-accounts.yaml?ref=doc-portal
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: service-accounts.yaml?ref=doc-portal
       kafkainstance:
         title: "OpenShift Streams for Apache Kafka Instance API"
-        api:
-          readonly: true
-          github:
-            owner: redhat-developer
-            repo: app-services-sdk-core
-            path: kafka-admin-rest.yaml?ref=doc-portal
+        readonly: true
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: kafka-admin-rest.yaml?ref=doc-portal
       registryinstance:
         title: "OpenShift Service Registry Instance API"
-        api:
-          readonly: true
-          github:
-            owner: redhat-developer
-            repo: app-services-sdk-core
-            path: registry-instance.json?ref=doc-portal
-
-
-
+        readonly: true
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: registry-instance.json?ref=doc-portal
 application-services:
   title: Application Services
   api:

--- a/main.yml
+++ b/main.yml
@@ -773,45 +773,55 @@ app-services-apis:
       kafkamgmt:
         title: "OpenShift Streams for Apache Kafka Management API"
         api:
-          owner: redhat-developer
-          repo: app-services-sdk-core
-          path: kas-fleet-manager.yaml?ref=doc-portal
+          github:
+            owner: redhat-developer
+            repo: app-services-sdk-core
+            path: kas-fleet-manager.yaml?ref=doc-portal
       connectormgmt:
         title: "OpenShift Connectors Management API "
         api:
-          owner: redhat-developer
-          repo: app-services-sdk-core
-          path: connector_mgmt?ref=doc-portal
+          github:
+            owner: redhat-developer
+            repo: app-services-sdk-core
+            path: connector_mgmt?ref=doc-portal
       serviceregistrymgmt:
         title: "OpenShift Service Registry Management API"
         api:
-          owner: redhat-developer
-          repo: app-services-sdk-core
-          path: srs-fleet-manager.json?ref=doc-portal
+          github:
+            owner: redhat-developer
+            repo: app-services-sdk-core
+            path: srs-fleet-manager.json?ref=doc-portal
       smarteventsmgmt:
         title: "Smart Events Management API"
         api:
-          owner: redhat-developer
-          repo: app-services-sdk-core
-          path: smartevents-mgmt.yaml?ref=doc-portal
+          github:
+            owner: redhat-developer
+            repo: app-services-sdk-core
+            path: smartevents-mgmt.yaml?ref=doc-portal
       serviceaccountsmgmt:
         title: "Service Accounts Management API"
         api:
-          owner: redhat-developer
-          repo: app-services-sdk-core
-          path: service-accounts.yaml?ref=doc-portal
+          github:
+            owner: redhat-developer
+            repo: app-services-sdk-core
+            path: service-accounts.yaml?ref=doc-portal
       kafkainstance:
         title: "OpenShift Streams for Apache Kafka Instance API"
         api:
-          owner: redhat-developer
-          repo: app-services-sdk-core
-          path: kafka-admin-rest.yaml?ref=doc-portal
+          readonly: true
+          github:
+            owner: redhat-developer
+            repo: app-services-sdk-core
+            path: kafka-admin-rest.yaml?ref=doc-portal
       registryinstance:
         title: "OpenShift Service Registry Instance API"
         api:
-          owner: redhat-developer
-          repo: app-services-sdk-core
-          path: registry-instance.json?ref=doc-portal
+          readonly: true
+          github:
+            owner: redhat-developer
+            repo: app-services-sdk-core
+            path: registry-instance.json?ref=doc-portal
+
 
 
 application-services:

--- a/validate-yaml.js
+++ b/validate-yaml.js
@@ -65,7 +65,7 @@ const schema = Joi.object({
         subItems: Joi.object().pattern(/^/ ,Joi.object({
             versions: [Joi.array().items(Joi.string()), Joi.string()],
             readonly: true,
-            github: Joi.object({ owner: Joi.string(), repo: Joi.string(), path: Joi.string() })
+            github: Joi.object({ owner: Joi.string(), repo: Joi.string(), path: Joi.string() }),
             title: Joi.string()
         })),
         tags: Joi.array().items(Joi.object({

--- a/validate-yaml.js
+++ b/validate-yaml.js
@@ -65,7 +65,7 @@ const schema = Joi.object({
         subItems: Joi.object().pattern(/^/ ,Joi.object({
             versions: [Joi.array().items(Joi.string()), Joi.string()],
             readonly: true,
-            github: Joi.object({ owner: Joi.string(), repo: Joi.string(), path: Joi.string())
+            github: Joi.object({ owner: Joi.string(), repo: Joi.string(), path: Joi.string() })
             title: Joi.string()
         })),
         tags: Joi.array().items(Joi.object({

--- a/validate-yaml.js
+++ b/validate-yaml.js
@@ -64,6 +64,8 @@ const schema = Joi.object({
         alias: Joi.array().items(Joi.string()),
         subItems: Joi.object().pattern(/^/ ,Joi.object({
             versions: [Joi.array().items(Joi.string()), Joi.string()],
+            readonly: true,
+            github: Joi.object({ owner: Joi.string(), repo: Joi.string(), path: Joi.string())
             title: Joi.string()
         })),
         tags: Joi.array().items(Joi.object({


### PR DESCRIPTION
I have added all github based APIs to the config based on the ability provided in:
https://github.com/RedHatInsights/api-frontend/pull/434

I do not know how to test it and looking for help.

## Why github

Some apis are available as public urls but some would be specific to the service instances. 
We also have chain of SDKs and other tooling that needs to be made available at the same time as updates in API portal. 
Github based API config is much more suitable for our use cases. 
