### PR TITLE
fix: app services in ci-stable

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -711,6 +711,55 @@ service-registry:
         title: Documentation
         navigate: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_registry
 
+## App Services (RHOAS) APIs
+app-services-apis:
+  title: Application Services
+  api:
+    subItems:
+      kafkamgmt:
+        title: "OpenShift Streams for Apache Kafka Management API"
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: kas-fleet-manager.yaml?ref=doc-portal
+      connectormgmt:
+        title: "OpenShift Connectors Management API "
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: connector_mgmt.yaml?ref=doc-portal
+      serviceregistrymgmt:
+        title: "OpenShift Service Registry Management API"
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: srs-fleet-manager.json?ref=doc-portal
+      smarteventsmgmt:
+        title: "Smart Events Management API"
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: smartevents-mgmt.yaml?ref=doc-portal
+      serviceaccountsmgmt:
+        title: "Service Accounts Management API"
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: service-accounts.yaml?ref=doc-portal
+      kafkainstance:
+        title: "OpenShift Streams for Apache Kafka Instance API"
+        readonly: true
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: kafka-admin-rest.yaml?ref=doc-portal
+      registryinstance:
+        title: "OpenShift Service Registry Instance API"
+        readonly: true
+        github:
+          owner: redhat-developer
+          repo: app-services-sdk-core
+          path: registry-instance.json?ref=doc-portal
 application-services:
   title: Application Services
   api:

--- a/validate-yaml.js
+++ b/validate-yaml.js
@@ -64,6 +64,8 @@ const schema = Joi.object({
         alias: Joi.array().items(Joi.string()),
         subItems: Joi.object().pattern(/^/ ,Joi.object({
             versions: [Joi.array().items(Joi.string()), Joi.string()],
+            readonly: Joi.boolean(),
+            github: Joi.object({ owner: Joi.string(), repo: Joi.string(), path: Joi.string() }),
             title: Joi.string()
         })),
         tags: Joi.array().items(Joi.object({


### PR DESCRIPTION
## Motivation

Managed services API portal changes have been merged to multiple branches.
This is last branch (ci-stable) to merge.

Exact the same API changes for prod-beta and prod-stable doesn't work (API doesn't show up the same way as in QA.

For production: No Application services visible 
For prod beta:
<img width="1324" alt="Screenshot 2022-08-08 at 11 15 00" src="https://user-images.githubusercontent.com/981838/183473834-851e5384-9e9b-445f-b872-c6804f84b3a9.png">

Changes made in both PRs are exactly the same as in ci-beta and ci-stable (this PR) 

https://github.com/RedHatInsights/cloud-services-config/pull/1255
https://github.com/RedHatInsights/cloud-services-config/pull/1256

Merging this PR will allow us:

- Align config across all envs 
- Test if issues production are related to some missing deployments etc.


