### PR TITLE
Update Documentation link for ACS

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -131,7 +131,7 @@
           {
               "title": "Documentation",
               "isExternal": true,
-              "href": "https://docs.openshift.com/acs/3.66/welcome/index.html"
+              "href": "https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes"
           }
       ]
     },


### PR DESCRIPTION
This change should use a more proper URL for accessing the latest docs for ACS