### PR TITLE
Add Vulnerability for OpenShift app to nav in prod-beta

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -552,6 +552,18 @@
             }
         ]
     },
+    "ocpVulnerability": {
+        "manifestLocation": "/apps/ocp-vulnerability/fed-mods.json",
+        "modules": [
+            {
+                "id": "ocp-vulnerability",
+                "module": "./RootApp",
+                "routes": [
+                    "/openshift/insights/vulnerability"
+                ]
+            }
+        ]
+    },
     "dbaas": {
         "manifestLocation": "/apps/dbaas/fed-mods.json",
         "modules": [

--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -59,6 +59,24 @@
                     ]
                 },
                 {
+                    "title": "Vulnerability",
+                    "expandable": true,
+                    "routes": [
+                        {
+                            "appId": "ocpVulnerability",
+                            "title": "CVEs",
+                            "href": "/openshift/insights/vulnerability/cves",
+                            "product": "Red Hat OpenShift Cluster Manager"
+                        },
+                        {
+                            "appId": "ocpVulnerability",
+                            "title": "Clusters",
+                            "href": "/openshift/insights/vulnerability/clusters",
+                            "product": "Red Hat OpenShift Cluster Manager"
+                        }
+                    ]
+                },
+                {
                     "title": "Subscriptions",
                     "expandable": true,
                     "filterable": true,

--- a/main.yml
+++ b/main.yml
@@ -623,6 +623,23 @@ ocp-advisor:
         title: Recommendations
         reload: recommendations
 
+ocp-vulnerability: 
+  title: Vulnerability
+  channel: '#forum-ccx-vulnerability'
+  source_repo: https://github.com/RedHatInsights/vuln4shift-frontend
+  deployment_repo: https://github.com/RedHatInsights/vuln4shift-frontend-build
+  frontend:
+    module: ocp-vulnerability#./RootApp
+    paths:
+      - /openshift/insights/vulnerability
+    sub_apps:
+      - id: cves
+        title: CVEs
+        reload: cves 
+      - id: clusters
+        title: Clusters
+        reload: clusters
+
 streams:
   title: "Streams for Apache Kafka"
   api:


### PR DESCRIPTION
App is deployed to prod-beta -- https://insights-dev-jenkins.apps.crcd01ue1.zmsj.p1.openshiftapps.com/job/insights-frontend-deployer/job/vuln4shift-frontend-build/

We'll do some testing and release the app to prod-stable in a week or so.