### PR TITLE
[stage-stable] Automation Hub - add Tasks menu item

### DIFF
--- a/chrome/ansible-navigation.json
+++ b/chrome/ansible-navigation.json
@@ -32,6 +32,12 @@
                 },
                 {
                     "appId": "automationHub",
+                    "title": "Task Management",
+                    "href": "/ansible/automation-hub/tasks",
+                    "product": "Ansible Automation Hub"
+                },
+                {
+                    "appId": "automationHub",
                     "title": "Connect to Hub",
                     "href": "/ansible/automation-hub/token",
                     "product": "Ansible Automation Hub"

--- a/main.yml
+++ b/main.yml
@@ -157,6 +157,8 @@ automation-hub:
         title: Partners
       - id: repositories
         title: Repo Management
+      - id: tasks
+        title: Task Management
       - id: token
         title: Connect to Hub
   source_repo: https://github.com/ansible/ansible-hub-ui


### PR DESCRIPTION
Backporting #1208 to stage-stable (aka ci-stable)

---

Part of issue https://issues.redhat.com/browse/AAH-1332, this pr adds an additional menu items "Task Management" to be visible on insights mode.

---

|branch|PR|
|-|-|
|ci-beta|#1208 (merged)|
|ci-stable|#1268 (here)|
|prod-beta|#1269|
|prod-stable|#1270|

(tracking issue: https://issues.redhat.com/browse/AAH-1874)