### PR TITLE
removes advisor from application settings

### DIFF
--- a/chrome/settings-navigation.json
+++ b/chrome/settings-navigation.json
@@ -106,27 +106,6 @@
             "routes": [
                 {
                     "appId": "applications",
-                    "title": "Advisor",
-                    "href": "/settings/applications/advisor",
-                    "permissions": [
-                        {
-                            "method": "isEntitled",
-                            "args": [
-                                "insights"
-                            ]
-                        },
-                        {
-                            "method": "hasPermissions",
-                            "args": [
-                                [
-                                    "advisor:*:*"
-                                ]
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "appId": "applications",
                     "title": "Cost Management",
                     "href": "/settings/applications/cost-management",
                     "permissions": [


### PR DESCRIPTION
removes Advisor nav from the 'Applications' app.

The url: https://console.stage.redhat.com/settings/applications/advisor