### PR TITLE
NOTIF-757 [prod] Fixes ordering adds console to user pref

### DIFF
--- a/chrome/user-preferences-navigation.json
+++ b/chrome/user-preferences-navigation.json
@@ -13,8 +13,8 @@
             "routes": [
                 {
                     "appId": "userPreferences",
-                    "title": "Red Hat Enterprise Linux",
-                    "href": "/user-preferences/notifications/rhel"
+                    "title": "Application Services",
+                    "href": "/user-preferences/notifications/application-services"
                 },
                 {
                     "appId": "userPreferences",
@@ -23,8 +23,13 @@
                 },
                 {
                     "appId": "userPreferences",
-                    "title": "Application Services",
-                    "href": "/user-preferences/notifications/application-services"
+                    "title": "Red Hat Enterprise Linux",
+                    "href": "/user-preferences/notifications/rhel"
+                },
+                {
+                    "appId": "userPreferences",
+                    "title": "Console",
+                    "href": "/user-preferences/notifications/console"
                 }
             ]
         }


### PR DESCRIPTION
Uses the same ordering as in [settings](https://console.redhat.com/settings/notifications/application-services):

![Screenshot_2022-08-25_13-34-06](https://user-images.githubusercontent.com/3845764/186752567-5aa16adc-9e09-4ef3-8754-1da569492016.png)

To be merged after https://github.com/RedHatInsights/user-preferences-frontend/pull/117 