### PR TITLE
Expose Provisioning wizard

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -302,6 +302,10 @@
             }
         ]
     },
+    "provisioning": {
+        "manifestLocation": "/apps/provisioning/fed-mods.json",
+        "modules": []
+    },
     "subscriptions": {
         "manifestLocation": "/apps/subscriptions/fed-mods.json",
         "modules": [

--- a/main.yml
+++ b/main.yml
@@ -752,6 +752,15 @@ onboarding:
       - /staging/test-onboarding-app
   source_repo: https://github.com/RedHatInsights/test-onboarding-app
 
+provisioning:
+  title: Launch
+  api:
+    versions:
+      - v1
+  channel: '#envision-team'
+  source_repo: https://github.com/RHEnVision/provisioning-frontend
+  deployment_repo: https://github.com/RedHatInsights/provisioning-frontend-build
+
 streams:
   title: "Streams for Apache Kafka"
   frontend:


### PR DESCRIPTION
My goal here: Another app being able to open up modal, that my app defines as a module.

I guess it's bit specific, so I'm not sure how to achieve this.
Ideally my app is not in the menu at all and is only opened from other app.

What should I do, is this correct? :)

Probably depends on https://github.com/RedHatInsights/frontend-components/pull/1623 & https://github.com/RHEnVision/provisioning-frontend/pull/118