### PR TITLE
Update application-services-navigation.json

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -123,8 +123,7 @@
       "routes": [
         {
           "appId": "acs",
-          "title": "ACS Instances",
-          "isBeta": true,
+          "title": "Overview",
           "href": "/application-services/acs/overview"
         },
         {


### PR DESCRIPTION
This PR updates the title of the Overview nav item. Seems like it wasn't fixed in the `ci-stable` branch