### PR TITLE
Mark provisioning as beta

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -760,6 +760,9 @@ provisioning:
   channel: '#envision-team'
   source_repo: https://github.com/RHEnVision/provisioning-frontend
   deployment_repo: https://github.com/RedHatInsights/provisioning-frontend-build
+  frontend:
+    title: Launch
+    isBeta: true
 
 streams:
   title: "Streams for Apache Kafka"


### PR DESCRIPTION
I still do not see my assets at `console.stage.redhat.com/<beta>/apps/provisioning/fed-mods.json`.
I took a stub at guessing it's because I did not mark my app as beta? :)