### PR TITLE
Remove isBeta flag from Vulnerability for OpenShift

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -66,15 +66,13 @@
                             "appId": "ocpVulnerability",
                             "title": "CVEs",
                             "href": "/openshift/insights/vulnerability/cves",
-                            "product": "Red Hat OpenShift Cluster Manager",
-                            "isBeta": true
+                            "product": "Red Hat OpenShift Cluster Manager"  
                         },
                         {
                             "appId": "ocpVulnerability",
                             "title": "Clusters",
                             "href": "/openshift/insights/vulnerability/clusters",
-                            "product": "Red Hat OpenShift Cluster Manager",
-                            "isBeta": true
+                            "product": "Red Hat OpenShift Cluster Manager"
                         }
                     ]
                 },


### PR DESCRIPTION
Vulnerability for OpenShift should become GA on Wednesday (19th Oct) 8 AM EST. Please merge this PR between 7:45 and 8:00 AM EST.

Thank you!