### PR TITLE
Add Malware detection app to RHEL navigation in ci-stable

### DIFF
--- a/chrome/rhel-navigation.json
+++ b/chrome/rhel-navigation.json
@@ -123,6 +123,24 @@
             ]
           },
           {
+            "title": "Malware",
+            "expandable": true,
+            "routes": [
+              {
+                "appId": "malware",
+                "title": "Signatures",
+                "href": "/insights/malware/signatures",
+                "product": "Red Hat Insights"
+              },
+              {
+                "appId": "malware",
+                "title": "Systems",
+                "href": "/insights/malware/systems",
+                "product": "Red Hat Insights"
+              }
+            ]
+          },
+          {
             "title": "Drift",
             "expandable": true,
             "routes": [


### PR DESCRIPTION
Malware detection is already present in navigation in stage-beta, prod-beta and prod-stable and this environment was forgotten.