### PR TITLE
Add Toolkit and Tasks app to prod-stable

### DIFF
--- a/chrome/ansible-navigation.json
+++ b/chrome/ansible-navigation.json
@@ -166,10 +166,16 @@
             "product": "Red Hat Insights"
         },
         {
-        "appId": "remediations",
-        "title": "Remediations",
-        "href": "/ansible/remediations",
-        "product": "Red Hat Insights"
+            "appId": "remediations",
+            "title": "Remediations",
+            "href": "/ansible/remediations",
+            "product": "Red Hat Insights"
+        },
+        {
+            "appId": "tasks",
+            "title": "Tasks",
+            "href": "/ansible/tasks",
+            "product": "Red Hat Insights"   
         }
     ]
 }

--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -369,6 +369,22 @@
             }
         ]
     },
+    "tasks": {
+        "manifestLocation": "/apps/tasks/fed-mods.json",
+        "modules": [
+            {
+                "id": "tasks",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/insights/tasks",
+                        "isFedramp": true
+                    },
+                    "/ansible/tasks"
+                ]
+            }
+        ]
+    },
     "ansibleDashboard": {
         "manifestLocation": "/apps/ansible-dashboard/fed-mods.json",
         "modules": [

--- a/chrome/rhel-navigation.json
+++ b/chrome/rhel-navigation.json
@@ -263,10 +263,22 @@
         "product": "Red Hat Insights"
       },
       {
-        "appId": "remediations",
-        "title": "Remediations",
-        "href": "/insights/remediations",
-        "product": "Red Hat Insights"
+        "title": "Toolkit",
+        "expandable": true,
+        "routes": [
+            {
+                "appId": "remediations",
+                "title": "Remediations",
+                "href": "/insights/remediations",
+                "product": "Red Hat Insights"
+            },
+            {
+                "appId": "tasks",
+                "title": "Tasks",
+                "href": "/insights/tasks",
+                "product": "Red Hat Insights"                    
+            }
+        ]
       },
       {
         "title": "Product Materials",

--- a/main.yml
+++ b/main.yml
@@ -1055,6 +1055,19 @@ subscriptions:
 
   source_repo: https://github.com/RedHatInsights/curiosity-frontend
 
+tasks:
+  title: Tasks
+  api:
+    versions:
+      - v1
+  channel: '#tasks'
+  deployment_repo: https://github.com/RedHatInsights/tasks-frontend-build
+  frontend:
+    module: tasks#./RootApp
+    paths:
+      - /insights/tasks
+  source_repo: https://github.com/RedHatInsights/tasks-frontend
+
 topological-inventory:
   title: Topological inventory
   top_level: true


### PR DESCRIPTION
Attempting to add Toolkit and Tasks to the side nav in prod-beta. Let me know if I've done this the wrong way.