### PR TITLE
Add malware api alias

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -575,6 +575,8 @@ malware:
   api:
     versions:
       - v1
+    alias:
+      - malware-detection
   channel: '#advisor'
   deployment_repo: https://github.com/RedHatInsights/malware-detection-frontend-build
   frontend:


### PR DESCRIPTION
Currently its looking for `api/malware/v1/openapi.json` instead of `api/malware-detection/v1/openapi.json`