### PR TITLE
[stage-beta] Add Subscription Watch OpenShift Data Science

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -150,9 +150,14 @@
           "expandable": true,
           "routes": [
             {
-              "appId": "applicationServices",
+              "appId": "subscriptions",
               "title": "Streams for Apache Kafka",
               "href": "/application-services/subscriptions/streams"
+            },
+            {
+              "appId": "subscriptions",
+              "title": "OpenShift Data Science",
+              "href": "/application-services/subscriptions/rhods"
             }
           ]
         }


### PR DESCRIPTION
Activates OpenShift Data Science for Subs Watch
[SWATCH-167]

@Hyperkid123 et all, If the `appId` needs to be updated let me know.

It's escaping our memory on why the `appId` for these is `applicationServices` when the other configs for Subscriptions under `insights/rhel` and `openshift`  reflect the `subscriptions` `appId` ... we don't use the `applicationServices` appId anywhere within our GUI