### PR TITLE
Add malware api alias

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -496,6 +496,8 @@ malware:
   api:
     versions:
       - v1
+    alias:
+      - malware-detection
   channel: '#advisor'
   deployment_repo: https://github.com/RedHatInsights/malware-detection-frontend-build
   frontend:


### PR DESCRIPTION
So that openapi contacts the correct API endpoint.