### PR TITLE
[stage-beta] Unify Subscription Watch RHEL, Satellite

### DIFF
--- a/chrome/rhel-navigation.json
+++ b/chrome/rhel-navigation.json
@@ -175,50 +175,14 @@
             "routes": [
               {
                 "appId": "subscriptions",
-                "title": "All RHEL",
+                "title": "RHEL",
                 "href": "/insights/subscriptions/rhel",
                 "product": "Subscription Watch"
               },
               {
                 "appId": "subscriptions",
-                "title": "ARM",
-                "href": "/insights/subscriptions/rhel-arm",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "IBM Power",
-                "href": "/insights/subscriptions/rhel-ibmpower",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "IBM Z systems",
-                "href": "/insights/subscriptions/rhel-ibmz",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "X86",
-                "href": "/insights/subscriptions/rhel-x86",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "All Satellite",
+                "title": "Satellite",
                 "href": "/insights/subscriptions/satellite",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "Satellite Capsule",
-                "href": "/insights/subscriptions/satellite-capsule",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "Satellite Server",
-                "href": "/insights/subscriptions/satellite-server",
                 "product": "Subscription Watch"
               },
               {


### PR DESCRIPTION
Reflects the unified Subs watch displays for RHEL, Satellite
[SWATCH-472]

- merged in conjunction with UI updates here https://github.com/RedHatInsights/curiosity-frontend/pull/1014
- planned for 2022-12-14ish