### PR TITLE
Add ACS to left navbar for customers

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -121,12 +121,6 @@
     {
       "title": "Advanced Cluster Security",
       "expandable": true,
-      "permissions": [
-        {
-          "method": "withEmail",
-          "args": ["@redhat.com"]
-        }
-      ],
       "routes": [
         {
           "appId": "acs",


### PR DESCRIPTION
Now that ACS is doing field trials, it should show up in the left navbar for customers, not just folks with @redhat.com email addresses.

cc @vjwilson @sachaudh @rukletsov