### PR TITLE
chore: MGDCTRS-1776 remove beta flag (#1383) (ci-stable)

### DIFF
--- a/chrome/application-services-navigation.json
+++ b/chrome/application-services-navigation.json
@@ -83,7 +83,6 @@
             {
               "appId": "applicationServices",
               "title": "Connectors Instances",
-              "isBeta": true,
               "href": "/application-services/connectors"
             },
             {


### PR DESCRIPTION
This change removes the beta flag for connectors from the navigation.