### PR TITLE
[ci-stable] Oracle Cloud Infrastructure link

### DIFF
--- a/chrome/openshift-navigation.json
+++ b/chrome/openshift-navigation.json
@@ -131,12 +131,7 @@
                             "href": "/openshift/cost-management/aws",
                             "product": "Red Hat Cost Management"
                         },
-                        {
-                            "appId": "costManagement",
-                            "title": "Microsoft Azure",
-                            "href": "/openshift/cost-management/azure",
-                            "product": "Red Hat Cost Management"
-                        },
+
                         {
                             "appId": "costManagement",
                             "title": "Google Cloud Platform",
@@ -147,6 +142,18 @@
                             "appId": "costManagement",
                             "title": "IBM Cloud",
                             "href": "/openshift/cost-management/ibm",
+                            "product": "Red Hat Cost Management"
+                        },
+                        {
+                            "appId": "costManagement",
+                            "title": "Microsoft Azure",
+                            "href": "/openshift/cost-management/azure",
+                            "product": "Red Hat Cost Management"
+                        },
+                        {
+                            "appId": "costManagement",
+                            "title": "Oracle Cloud Infrastructure",
+                            "href": "/openshift/cost-management/oci",
                             "product": "Red Hat Cost Management"
                         },
                         {

--- a/main.yml
+++ b/main.yml
@@ -296,14 +296,17 @@ cost-management:
       - id: aws
         title: Amazon Web Services
         group: cost-management
-      - id: azure
-        title: Microsoft Azure
-        group: cost-management
       - id: gcp
         title: Google Cloud Platform
         group: cost-management
       - id: ibm
         title: IBM Cloud
+        group: cost-management
+      - id: azure
+        title: Microsoft Azure
+        group: cost-management
+      - id: oci
+        title: Oracle Cloud Infrastructure
         group: cost-management
       - id: cost-models
         title: Cost models


### PR DESCRIPTION
Add Cost Management's "Oracle Cloud Infrastructure" link to the Insights navigation pane.

