### PR TITLE
Update the nav title to App Studio

### DIFF
--- a/chrome/hac-navigation.json
+++ b/chrome/hac-navigation.json
@@ -1,6 +1,6 @@
 {
   "id": "hac",
-  "title": "StoneSoup",
+  "title": "App Studio",
   "navItems": [
       {
         "title": "Demo Plugin",

--- a/chrome/hac-navigation.json
+++ b/chrome/hac-navigation.json
@@ -1,6 +1,6 @@
 {
   "id": "hac",
-  "title": "App Studio",
+  "title": "CI/CD",
   "navItems": [
       {
         "title": "Demo Plugin",


### PR DESCRIPTION
App Studio is the only approved marketing name right now so we need to use it until we get a new product name for StoneSoup.