### PR TITLE
Preparing navigation for inventory groups

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -258,6 +258,16 @@
                     },
                     "/ansible/inventory"
                 ]
+            },
+            {
+                "id": "groups",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/insights/inventory/groups",
+                        "isFedramp": true
+                    }
+                ]
             }
         ]
     },

--- a/chrome/rhel-navigation.json
+++ b/chrome/rhel-navigation.json
@@ -1,270 +1,281 @@
 {
-    "id": "rhel",
-    "title": "Red Hat Insights",
-    "navItems": [
-      {
-        "appId": "dashboard",
-        "title": "Overview",
-        "filterable": false,
-        "href": "/insights/dashboard",
-        "product": "Red Hat Insights"
-      },
-      {
-        "groupId": "business",
-        "icon": "trend-up",
-        "title": "Red Hat Insights",
-        "navItems": [
-          {
-            "appId": "inventory",
-            "title": "Inventory",
-            "href": "/insights/inventory",
-            "product": "Red Hat Insights"
-          },
-          {
-            "title": "Advisor",
-            "expandable": true,
-            "routes": [
-              {
-                "appId": "advisor",
-                "title": "Recommendations",
-                "href": "/insights/advisor/recommendations",
-                "product": "Red Hat Insights"
-              },
-              {
-                "appId": "advisor",
-                "title": "Systems",
-                "href": "/insights/advisor/systems",
-                "product": "Red Hat Insights"
-              },
-              {
-                "appId": "advisor",
-                "title": "Topics",
-                "href": "/insights/advisor/topics",
-                "product": "Red Hat Insights"
-              }
-            ]
-          },
-          {
-            "title": "Patch",
-            "expandable": true,
-            "routes": [
-              {
-                "appId": "patch",
-                "title": "Advisories",
-                "href": "/insights/patch/advisories",
-                "product": "Red Hat Insights"
-              },
-              {
-                "appId": "patch",
-                "title": "Systems",
-                "href": "/insights/patch/systems",
-                "product": "Red Hat Insights"
-              },
-              {
-                "appId": "patch",
-                "title": "Packages",
-                "href": "/insights/patch/packages",
-                "product": "Red Hat Insights"
-              },
-              {
-                "appId": "patch",
-                "title": "Templates",
-                "href": "/insights/patch/templates",
-                "product": "Red Hat Insights"
-              }
-            ]
-          },
-          {
-            "title": "Vulnerability",
-            "expandable": true,
-            "routes": [
-              {
-                "appId": "vulnerability",
-                "title": "CVEs",
-                "href": "/insights/vulnerability/cves",
-                "product": "Red Hat Insights"
-              },
-              {
-                "appId": "vulnerability",
-                "title": "Reports",
-                "href": "/insights/vulnerability/reports",
-                "product": "Red Hat Insights"
-              },
-              {
-                "appId": "vulnerability",
-                "title": "Systems",
-                "href": "/insights/vulnerability/systems",
-                "product": "Red Hat Insights"
-              }
-            ]
-          },
-          {
-            "title": "Compliance",
-            "expandable": true,
-            "routes": [
-              {
-                "appId": "compliance",
-                "title": "Reports",
-                "href": "/insights/compliance/reports",
-                "product": "Red Hat Insights"
-              },
-              {
-                "appId": "compliance",
-                "title": "SCAP Policies",
-                "href": "/insights/compliance/scappolicies",
-                "product": "Red Hat Insights"
-              },
-              {
-                "appId": "compliance",
-                "title": "Systems",
-                "href": "/insights/compliance/systems",
-                "product": "Red Hat Insights"
-              }
-            ]
-          },
-          {
-            "title": "Malware",
-            "expandable": true,
-            "routes": [
-              {
-                "appId": "malware",
-                "title": "Signatures",
-                "href": "/insights/malware/signatures",
-                "product": "Red Hat Insights"
-              },
-              {
-                "appId": "malware",
-                "title": "Systems",
-                "href": "/insights/malware/systems",
-                "product": "Red Hat Insights"
-              }
-            ]
-          },
-          {
-            "title": "Drift",
-            "expandable": true,
-            "routes": [
-              {
-                "appId": "drift",
-                "title": "Comparison",
-                "href": "/insights/drift/",
-                "product": "Red Hat Insights"
-              },
-              {
-                "appId": "drift",
-                "title": "Baselines",
-                "href": "/insights/drift/baselines",
-                "product": "Red Hat Insights"
-              }
-            ]
-          },
-          {
-            "appId": "ros",
-            "title": "Resource Optimization",
-            "href": "/insights/ros",
-            "product": "Red Hat Insights"
-          },
-          {
-            "appId": "policies",
-            "title": "Policies",
-            "href": "/insights/policies"
-          },
-          {
-            "expandable": true,
-            "title": "Subscriptions",
-            "routes": [
-              {
-                "appId": "subscriptions",
-                "title": "RHEL",
-                "href": "/insights/subscriptions/rhel",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "Satellite",
-                "href": "/insights/subscriptions/satellite",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "OpenShift Subscriptions",
-                "href": "/openshift/subscriptions/openshift-container",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptionInventory",
-                "title": "Subscription Inventory",
-                "href": "/insights/subscriptions/inventory",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "manifests",
-                "title": "Manifests",
-                "href": "/insights/subscriptions/manifests",
-                "product": "Subscription Watch"
-              },
-              {
-                "title": "Documentation",
-                "isExternal": true,
-                "filterable": false,
-                "href": "https://access.redhat.com/products/subscription-central"
-              }
-            ]
-          },
-          {
-            "appId": "image_builder",
-            "title": "Image builder",
-            "href": "/insights/image-builder",
-            "product": "Red Hat Insights"
-          }
-        ]
-      },
-      {
-        "appId": "registration",
-        "title": "Register Systems",
-        "filterable": false,
-        "href": "/insights/registration",
-        "product": "Red Hat Insights"
-      },
-      {
-        "title": "Toolkit",
-        "expandable": true,
-        "routes": [
+  "id": "rhel",
+  "title": "Red Hat Insights",
+  "navItems": [
+    {
+      "appId": "dashboard",
+      "title": "Overview",
+      "filterable": false,
+      "href": "/insights/dashboard",
+      "product": "Red Hat Insights"
+    },
+    {
+      "groupId": "business",
+      "icon": "trend-up",
+      "title": "Red Hat Insights",
+      "navItems": [
+        {
+          "title": "Inventory",
+          "expandable": true,
+          "routes": [
             {
-                "appId": "remediations",
-                "title": "Remediations",
-                "href": "/insights/remediations",
-                "product": "Red Hat Insights"
+              "appId": "inventory",
+              "title": "Groups",
+              "href": "/insights/inventory/groups",
+              "product": "Red Hat Insights"
             },
             {
-                "appId": "tasks",
-                "title": "Tasks",
-                "href": "/insights/tasks",
-                "product": "Red Hat Insights"
+              "appId": "inventory",
+              "title": "Systems",
+              "href": "/insights/inventory",
+              "product": "Red Hat Insights"
             }
-        ]
-      },
-      {
-        "title": "Product Materials",
-        "expandable": true,
-        "routes": [
-          {
-            "title": "Documentation",
-            "isExternal": true,
-            "href": "https://access.redhat.com/documentation/en-us/red_hat_insights/"
-          },
-          {
-            "appId": "trust",
-            "title": "Security Information",
-            "href": "/security/insights"
-          },
-          {
-            "appId": "apiDocs",
-            "title": "APIs",
-            "href": "/docs/api"
-          }
-        ]
-      }
-    ]
+          ]
+        },
+        {
+          "title": "Advisor",
+          "expandable": true,
+          "routes": [
+            {
+              "appId": "advisor",
+              "title": "Recommendations",
+              "href": "/insights/advisor/recommendations",
+              "product": "Red Hat Insights"
+            },
+            {
+              "appId": "advisor",
+              "title": "Systems",
+              "href": "/insights/advisor/systems",
+              "product": "Red Hat Insights"
+            },
+            {
+              "appId": "advisor",
+              "title": "Topics",
+              "href": "/insights/advisor/topics",
+              "product": "Red Hat Insights"
+            }
+          ]
+        },
+        {
+          "title": "Patch",
+          "expandable": true,
+          "routes": [
+            {
+              "appId": "patch",
+              "title": "Advisories",
+              "href": "/insights/patch/advisories",
+              "product": "Red Hat Insights"
+            },
+            {
+              "appId": "patch",
+              "title": "Systems",
+              "href": "/insights/patch/systems",
+              "product": "Red Hat Insights"
+            },
+            {
+              "appId": "patch",
+              "title": "Packages",
+              "href": "/insights/patch/packages",
+              "product": "Red Hat Insights"
+            },
+            {
+              "appId": "patch",
+              "title": "Templates",
+              "href": "/insights/patch/templates",
+              "product": "Red Hat Insights"
+            }
+          ]
+        },
+        {
+          "title": "Vulnerability",
+          "expandable": true,
+          "routes": [
+            {
+              "appId": "vulnerability",
+              "title": "CVEs",
+              "href": "/insights/vulnerability/cves",
+              "product": "Red Hat Insights"
+            },
+            {
+              "appId": "vulnerability",
+              "title": "Reports",
+              "href": "/insights/vulnerability/reports",
+              "product": "Red Hat Insights"
+            },
+            {
+              "appId": "vulnerability",
+              "title": "Systems",
+              "href": "/insights/vulnerability/systems",
+              "product": "Red Hat Insights"
+            }
+          ]
+        },
+        {
+          "title": "Compliance",
+          "expandable": true,
+          "routes": [
+            {
+              "appId": "compliance",
+              "title": "Reports",
+              "href": "/insights/compliance/reports",
+              "product": "Red Hat Insights"
+            },
+            {
+              "appId": "compliance",
+              "title": "SCAP Policies",
+              "href": "/insights/compliance/scappolicies",
+              "product": "Red Hat Insights"
+            },
+            {
+              "appId": "compliance",
+              "title": "Systems",
+              "href": "/insights/compliance/systems",
+              "product": "Red Hat Insights"
+            }
+          ]
+        },
+        {
+          "title": "Malware",
+          "expandable": true,
+          "routes": [
+            {
+              "appId": "malware",
+              "title": "Signatures",
+              "href": "/insights/malware/signatures",
+              "product": "Red Hat Insights"
+            },
+            {
+              "appId": "malware",
+              "title": "Systems",
+              "href": "/insights/malware/systems",
+              "product": "Red Hat Insights"
+            }
+          ]
+        },
+        {
+          "title": "Drift",
+          "expandable": true,
+          "routes": [
+            {
+              "appId": "drift",
+              "title": "Comparison",
+              "href": "/insights/drift/",
+              "product": "Red Hat Insights"
+            },
+            {
+              "appId": "drift",
+              "title": "Baselines",
+              "href": "/insights/drift/baselines",
+              "product": "Red Hat Insights"
+            }
+          ]
+        },
+        {
+          "appId": "ros",
+          "title": "Resource Optimization",
+          "href": "/insights/ros",
+          "product": "Red Hat Insights"
+        },
+        {
+          "appId": "policies",
+          "title": "Policies",
+          "href": "/insights/policies"
+        },
+        {
+          "expandable": true,
+          "title": "Subscriptions",
+          "routes": [
+            {
+              "appId": "subscriptions",
+              "title": "RHEL",
+              "href": "/insights/subscriptions/rhel",
+              "product": "Subscription Watch"
+            },
+            {
+              "appId": "subscriptions",
+              "title": "Satellite",
+              "href": "/insights/subscriptions/satellite",
+              "product": "Subscription Watch"
+            },
+            {
+              "appId": "subscriptions",
+              "title": "OpenShift Subscriptions",
+              "href": "/openshift/subscriptions/openshift-container",
+              "product": "Subscription Watch"
+            },
+            {
+              "appId": "subscriptionInventory",
+              "title": "Subscription Inventory",
+              "href": "/insights/subscriptions/inventory",
+              "product": "Subscription Watch"
+            },
+            {
+              "appId": "manifests",
+              "title": "Manifests",
+              "href": "/insights/subscriptions/manifests",
+              "product": "Subscription Watch"
+            },
+            {
+              "title": "Documentation",
+              "isExternal": true,
+              "filterable": false,
+              "href": "https://access.redhat.com/products/subscription-central"
+            }
+          ]
+        },
+        {
+          "appId": "image_builder",
+          "title": "Image builder",
+          "href": "/insights/image-builder",
+          "product": "Red Hat Insights"
+        }
+      ]
+    },
+    {
+      "appId": "registration",
+      "title": "Register Systems",
+      "filterable": false,
+      "href": "/insights/registration",
+      "product": "Red Hat Insights"
+    },
+    {
+      "title": "Toolkit",
+      "expandable": true,
+      "routes": [
+        {
+          "appId": "remediations",
+          "title": "Remediations",
+          "href": "/insights/remediations",
+          "product": "Red Hat Insights"
+        },
+        {
+          "appId": "tasks",
+          "title": "Tasks",
+          "href": "/insights/tasks",
+          "product": "Red Hat Insights"
+        }
+      ]
+    },
+    {
+      "title": "Product Materials",
+      "expandable": true,
+      "routes": [
+        {
+          "title": "Documentation",
+          "isExternal": true,
+          "href": "https://access.redhat.com/documentation/en-us/red_hat_insights/"
+        },
+        {
+          "appId": "trust",
+          "title": "Security Information",
+          "href": "/security/insights"
+        },
+        {
+          "appId": "apiDocs",
+          "title": "APIs",
+          "href": "/docs/api"
+        }
+      ]
+    }
+  ]
 }
-

--- a/main.yml
+++ b/main.yml
@@ -559,8 +559,15 @@ internal:
 inventory:
   title: Managed Inventory
   api:
-    versions:
-      - v1
+    subItems:
+      groups:
+        versions:
+          - v1
+        title: Groups
+      systems:
+        versions:
+          - v1
+        title: Systems
   channel: '#flip-mode-squad'
   deployment_repo: https://github.com/RedHatInsights/insights-inventory-frontend-build
   frontend:
@@ -569,12 +576,19 @@ inventory:
     section: operations
     paths:
       - /insights/inventory
+    sub_apps:
+      - id: systems
+        title: Systems
+        default: true
+      - id: groups
+        title: Groups
   source_repo: https://github.com/RedHatInsights/insights-inventory-frontend
 
 landing:
   channel: '#flip-mode-squad'
   deployment_repo: https://github.com/RedHatInsights/landing-page-frontend-build
   source_repo: https://github.com/RedHatInsights/landing-page-frontend
+
 
 malware:
   title: Malware


### PR DESCRIPTION
Task link:
https://issues.redhat.com/browse/ESSNTL-4191

Preparing navigation for the inventory groups
Please check the PR to see if I edited the path's for the inventory correctly
The URL address for the inventory-groups will be insights/inventory/groups but I have to move the existing inventory table to the sub-item.
Sketch:
![image](https://user-images.githubusercontent.com/62722417/216012356-f0925084-7eb2-4dab-bf00-4764cd32ec92.png)

