### PR TITLE
[prod-beta] Unify Subscription Watch RHEL archs, Satellite variants

### DIFF
--- a/chrome/rhel-navigation.json
+++ b/chrome/rhel-navigation.json
@@ -175,50 +175,14 @@
             "routes": [
               {
                 "appId": "subscriptions",
-                "title": "All RHEL",
+                "title": "RHEL",
                 "href": "/insights/subscriptions/rhel",
                 "product": "Subscription Watch"
               },
               {
                 "appId": "subscriptions",
-                "title": "ARM",
-                "href": "/insights/subscriptions/rhel-arm",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "IBM Power",
-                "href": "/insights/subscriptions/rhel-ibmpower",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "IBM Z systems",
-                "href": "/insights/subscriptions/rhel-ibmz",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "X86",
-                "href": "/insights/subscriptions/rhel-x86",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "All Satellite",
+                "title": "Satellite",
                 "href": "/insights/subscriptions/satellite",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "Satellite Capsule",
-                "href": "/insights/subscriptions/satellite-capsule",
-                "product": "Subscription Watch"
-              },
-              {
-                "appId": "subscriptions",
-                "title": "Satellite Server",
-                "href": "/insights/subscriptions/satellite-server",
                 "product": "Subscription Watch"
               },
               {


### PR DESCRIPTION
Reflects the unified Subs watch displays for RHEL, Satellite
[SWATCH-472]

@Hyperkid123 et all we're releasing the corresponding GUI code to prod-beta tomorrow, Feb 13th, 8:00 AM EST. This update doesn't break anything, and it is prod-beta, but it would helpful if this was merged/released, at your convenience, in the vicinity of 8:00 AM EST, hour or two diff.
