### PR TITLE
Remove unused Ansible Automation Analytics routes

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -487,14 +487,7 @@
                 "id": "ansible-automation-analytics",
                 "module": "./RootApp",
                 "routes": [
-                    "/ansible/automation-analytics",
-                    "/ansible/reports",
-                    "/ansible/savings-planner",
-                    "/ansible/automation-calculator",
-                    "/ansible/organization-statistics",
-                    "/ansible/job-explorer",
-                    "/ansible/clusters",
-                    "/ansible/notifications"
+                    "/ansible/automation-analytics"
                 ]
             }
         ]


### PR DESCRIPTION
Remove unused Ansible Automation Analytics routes to prevent Router to prefer them over used ones after update to react-router-dom v.6

cc @Hyperkid123 