### PR TITLE
Revert "Remove unused Ansible Automation Analytics routes"

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -487,7 +487,14 @@
                 "id": "ansible-automation-analytics",
                 "module": "./RootApp",
                 "routes": [
-                    "/ansible/automation-analytics"
+                    "/ansible/automation-analytics",
+                    "/ansible/reports",
+                    "/ansible/savings-planner",
+                    "/ansible/automation-calculator",
+                    "/ansible/organization-statistics",
+                    "/ansible/job-explorer",
+                    "/ansible/clusters",
+                    "/ansible/notifications"
                 ]
             }
         ]


### PR DESCRIPTION
This reverts commit 2c4e1f1ce49daae3131d3f2da5ab75b74a00ba7f.