### PR TITLE
feat: add rhosak UI to prod beta

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -440,9 +440,34 @@
             }
         ]
     },
+    "rhosak": {
+        "manifestLocation": "/apps/rhosak/fed-mods.json",
+        "analytics": {
+            "APIKey": "eGAB8pv9DFgdj80STEaeHSMvRPAjdDUH"
+        },
+        "modules": [
+            {
+                "id": "rhosak",
+                "module": "./RootApp",
+                "routes": ["/application-services/streams"]
+            }
+        ]
+    },
+    "srs": {
+        "manifestLocation": "/apps/srs-ui-build/fed-mods.json",
+        "modules": []
+    },
+    "ar": {
+        "manifestLocation": "/apps/sr-ui-build/fed-mods.json",
+        "modules": []
+    },
+    "guides": {
+        "manifestLocation": "/apps/rhoas-guides-build/fed-mods.json",
+        "modules": []
+    },
     "applicationServices": {
         "manifestLocation": "/apps/application-services/fed-mods.json",
-	"analytics": {
+	    "analytics": {
           "APIKey": "eGAB8pv9DFgdj80STEaeHSMvRPAjdDUH"
         },
         "modules": [


### PR DESCRIPTION
We want to test the new UI in production but in the beta environment, before pulling the plug on the stable one. This adds the required config.