### PR TITLE
chore: remove conflicting URL

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -475,8 +475,7 @@
                 "id": "application-services",
                 "module": "./RootApp",
                 "routes": [
-                    "/application-services",
-                    "/application-services/streams"
+                    "/application-services"
                 ]
             }
         ]


### PR DESCRIPTION
"/application-services/streams" is handled by rhosak now. Some users reported that they could not see the new UI served at that URL while I could, so I suppose the priority isn't guaranteed on the order in which the routes are listed in the json.

The overlapping route doesn't have any sense anyway, so better remove it.