### PR TITLE
Require full profile for sources application. (#1427)

### DIFF
--- a/chrome/fed-modules.json
+++ b/chrome/fed-modules.json
@@ -87,6 +87,7 @@
     },
     "sources": {
         "manifestLocation": "/apps/sources/fed-mods.json",
+        "fullProfile": true,
         "modules": [
             {
                 "id": "sources",

--- a/chrome/validationSchemas/modules.js
+++ b/chrome/validationSchemas/modules.js
@@ -44,7 +44,8 @@ const moduleItemSchema = Joi.object({
   modules: Joi.array().items(routeModuleSchema).required(),
   analytics: Joi.object({
     APIKey: Joi.string().required()
-  })
+  }),
+  fullProfile: Joi.boolean().optional()
 })
 
 const modulesSchema = Joi.object().pattern(Joi.string().token(), moduleItemSchema);


### PR DESCRIPTION
NOTE: Sources app does not require full auth profile. This flag is was added to test the full profile UI integration only in stage beta environment.